### PR TITLE
Fix action button color and width

### DIFF
--- a/src/components/ActionButton.jsx
+++ b/src/components/ActionButton.jsx
@@ -12,12 +12,15 @@ const ActionButton = ({ link, text }) => {
         variant="contained"
         sx={(theme) => ({
           margin: '1rem',
-          bgcolor: 'accents.accent1',
+          bgcolor: '#1B2B7B',
+          padding: '8px 24px 8px 24px',
           color: 'accents.contrastText',
-          width: '12rem',
           borderRadius: 40,
           ':hover': {
             bgcolor: 'accents.accent1',
+          },
+          [theme.breakpoints.down('sm')]: {
+            width: '300px',
           },
         })}
         size="small"

--- a/src/components/ActionButton.jsx
+++ b/src/components/ActionButton.jsx
@@ -12,7 +12,7 @@ const ActionButton = ({ link, text }) => {
         variant="contained"
         sx={(theme) => ({
           margin: '1rem',
-          bgcolor: '#1B2B7B',
+          bgcolor: 'accents.accent1',
           padding: '8px 24px 8px 24px',
           color: 'accents.contrastText',
           borderRadius: 40,

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -15,7 +15,7 @@ declare module '@mui/material/styles' {
 const theme = createTheme({
   palette: {
     primary: {
-      main: '#556cd6',
+      main: '#1B2B7B',
     },
     secondary: {
       main: '#F79234',


### PR DESCRIPTION
## Problem 
Fixes: #82 

## Solution 
Change the css setting of the ActionButton 

## Screenshot 
- Before
<img width="819" alt="截圖 2022-03-22 上午12 04 58" src="https://user-images.githubusercontent.com/61721490/159426088-1f66adae-ba35-4a70-bda3-938ab58c0cd7.png">


- After 
<img width="391" alt="截圖 2022-03-22 上午12 03 41" src="https://user-images.githubusercontent.com/61721490/159425926-f6b0fc8b-efec-4681-b163-e64c2f5fcc04.png">

- After(Mobile)
<img width="388" alt="截圖 2022-03-22 上午12 06 16" src="https://user-images.githubusercontent.com/61721490/159426286-27c48a4f-7ba7-4592-95b1-f3750c374bb4.png">
esign) 

