### PR TITLE
Update 'Send Feedback' nav link URL

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -51,7 +51,7 @@ const navLinks = [
   },
   {
     name: 'Send Feedback',
-    url: '/',
+    url: 'https://docs.google.com/forms/d/e/1FAIpQLScsBwU_ZX0W2GUrxJ5JKb3PfR-NmloHxm7zetkyOBC5RM2ajA/viewform',
     icon: '',
   },
 ]


### PR DESCRIPTION
Changed the 'Send Feedback' navigation link to point to a Google Forms feedback form instead of the home page.