### PR TITLE
Learn page copy edits

### DIFF
--- a/src/pages/learn.jsx
+++ b/src/pages/learn.jsx
@@ -156,10 +156,7 @@ export const learn = () => {
                 />
               </Box>
               <Typography variant="h6" fontWeight="600" mb={1}>
-                J pod&apos;s Favorite call: 501
-              </Typography>
-              <Typography variant="body2" color="text.secondary" mb={2}>
-                More description goes here
+                J pod&apos;s Favorite call: S01
               </Typography>
               <ReactAudioPlayer
                 src={audio}
@@ -178,10 +175,7 @@ export const learn = () => {
                 />
               </Box>
               <Typography variant="h6" fontWeight="600" mb={1}>
-                K pod&apos;s Favorite call: 516
-              </Typography>
-              <Typography variant="body2" color="text.secondary" mb={2}>
-                More description goes here
+                K pod&apos;s Favorite call: S16
               </Typography>
               <ReactAudioPlayer
                 src={audio}
@@ -200,10 +194,7 @@ export const learn = () => {
                 />
               </Box>
               <Typography variant="h6" fontWeight="600" mb={1}>
-                L pod&apos;s Favorite call: 519
-              </Typography>
-              <Typography variant="body2" color="text.secondary" mb={2}>
-                More description goes here
+                L pod&apos;s Favorite call: S19
               </Typography>
               <ReactAudioPlayer
                 src={audio}


### PR DESCRIPTION
This pull request makes minor updates to the `learn` page, specifically updating the favorite call identifiers for J, K, and L pods.

* Updated favorite call identifiers for pods:
  * Changed J pod's favorite call from `501` to `S01` in `src/pages/learn.jsx`.
  * Changed K pod's favorite call from `516` to `S16` in `src/pages/learn.jsx`.
  * Changed L pod's favorite call from `519` to `S19` in `src/pages/learn.jsx`.

* Removed placeholder descriptions for each pod's favorite call in `src/pages/learn.jsx`. [[1]](diffhunk://#diff-eb8f3181f7a4b2ae745cafe30630dd739e497d58a95ac7e23c9013609573fbb3L159-R159) [[2]](diffhunk://#diff-eb8f3181f7a4b2ae745cafe30630dd739e497d58a95ac7e23c9013609573fbb3L181-R178) [[3]](diffhunk://#diff-eb8f3181f7a4b2ae745cafe30630dd739e497d58a95ac7e23c9013609573fbb3L203-R197)