### PR TITLE
Add Google Analytics gtag to _app

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import CssBaseline from '@mui/material/CssBaseline'
 import { ThemeProvider } from '@mui/material/styles'
 import { AppProps } from 'next/app'
 import Head from 'next/head'
+import Script from 'next/script'
 
 import Layout from '../components/Layout'
 import theme from '../styles/theme'
@@ -25,6 +26,18 @@ export default function MyApp(props: MyAppProps) {
       <Head>
         <meta name="viewport" content="initial-scale=1, width=device-width" />
       </Head>
+      <Script
+        src="https://www.googletagmanager.com/gtag/js?id=G-ZVQHKE47R1"
+        strategy="afterInteractive"
+      />
+      <Script id="gtag-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-ZVQHKE47R1');
+        `}
+      </Script>
       <ThemeProvider theme={theme}>
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />


### PR DESCRIPTION
Import next/script and add Google Analytics (gtag) to src/pages/_app.tsx. The change loads gtag.js with strategy "afterInteractive" and injects an initialization script that sets up window.dataLayer and calls google tag to enable page tracking.