### PR TITLE
Fix typo: Behaviour -> Behavior in DonatePartners

### DIFF
--- a/src/components/Donate/DonatePartners.jsx
+++ b/src/components/Donate/DonatePartners.jsx
@@ -26,7 +26,7 @@ const partners = [
   },
   {
     icon: '/images/donatePartners/orca-behavior-institute-logo-white.svg',
-    name: 'Orca Behaviour Institute',
+    name: 'Orca Behavior Institute',
     description:
       'Orca Behavior Institute conducts non-invasive research on orcas and helps others learn how to protect these animals.',
     linkTo: 'https://orcabehaviorinstitute.org/',


### PR DESCRIPTION
Fixes a typo on the /donate page where 'Orca Behaviour Institute' was spelled with the British English spelling. Changed to 'Orca Behavior Institute' to match the organization's actual name and the spelling used elsewhere in the codebase.