### PR TITLE
Update year in footer to 2026

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -16,6 +16,8 @@ import xlogo from '../../public/images/x_invert.png'
 import youtubelogo from '../../public/images/youtube.png'
 import useIsMobile from '../utils/useIsMobile'
 
+const currentYear = new Date().getFullYear()
+
 const StyledTypography = styled(Typography)({
   color: 'white',
   marginRight: '32px',
@@ -209,7 +211,7 @@ function Mobile() {
         {iconContainer}
         <Box sx={{ marginTop: '20px', textAlign: 'center' }}>
           <Typography variant="body2" color="white">
-            &copy; 2026 Orcasound. All rights reserved.
+            &copy; {currentYear} Orcasound. All rights reserved.
           </Typography>
         </Box>
       </AppBar>
@@ -366,7 +368,7 @@ function Desktop() {
             }}
           >
             <Typography variant="body2" color="white">
-              &copy; 2026 Orcasound. All rights reserved.
+              &copy; {currentYear} Orcasound. All rights reserved.
             </Typography>
           </Box>
         </Box>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -366,7 +366,7 @@ function Desktop() {
             }}
           >
             <Typography variant="body2" color="white">
-              &copy; 2025 Orcasound. All rights reserved.
+              &copy; 2026 Orcasound. All rights reserved.
             </Typography>
           </Box>
         </Box>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -209,7 +209,7 @@ function Mobile() {
         {iconContainer}
         <Box sx={{ marginTop: '20px', textAlign: 'center' }}>
           <Typography variant="body2" color="white">
-            &copy; 2025 Orcasound. All rights reserved.
+            &copy; 2026 Orcasound. All rights reserved.
           </Typography>
         </Box>
       </AppBar>


### PR DESCRIPTION
This pull request makes a small update to the copyright year displayed in the footer.

* The copyright year in the `Mobile` component in `Footer.jsx` was updated from 2025 to 2026.

Addresses #207 