### PR TITLE
fix: correct Orca Behavior Institute donate CTA URL

### DIFF
--- a/src/components/Donate/DonatePartners.jsx
+++ b/src/components/Donate/DonatePartners.jsx
@@ -31,7 +31,7 @@ const partners = [
     name: 'Orca Behavior Institute',
     description:
       'Orca Behavior Institute conducts non-invasive research on orcas and helps others learn how to protect these animals.',
-    linkTo: 'https://orcabehaviorinstitute.org/',
+    linkTo: 'https://www.orcabehaviorinstitute.org/donate',
   },
   {
     icon: '/images/donatePartners/OrcaConservancy.svg',


### PR DESCRIPTION
Update the donate link from https://orcabehaviorinstitute.org/ to https://www.orcabehaviorinstitute.org/donate so the CTA goes directly to their donation page.

Closes #212