### PR TITLE
fix: correct F.O.L.K.S. donate CTA URL

### DIFF
--- a/src/components/Donate/DonatePartners.jsx
+++ b/src/components/Donate/DonatePartners.jsx
@@ -24,7 +24,7 @@ const partners = [
     name: 'F.O.L.K.S',
     description:
       "F.O.L.K.S. provides visitors with education on the Salish Sea's diverse marine ecosystem.",
-    linkTo: 'https://folkssji.org/donate/',
+    linkTo: 'https://folkssji.org/donate-today',
   },
   {
     icon: '/images/donatePartners/orca-behavior-institute-logo-white.svg',


### PR DESCRIPTION
Update the donate link from https://folkssji.org/donate/ to https://folkssji.org/donate-today so the CTA goes to the correct donation page.

Closes #211