### PR TITLE
feat: rename user-facing 'Donate' strings to 'Support' (#217)

### DIFF
--- a/src/components/Donate/DonateOrcasound.tsx
+++ b/src/components/Donate/DonateOrcasound.tsx
@@ -60,7 +60,7 @@ const DonateOrcasound = (props: DonateOrcasoundProps) => {
         <ImageContainer>
           <Image
             src={props.donateOrcasoundImage}
-            alt="Picture of Support Orcasound"
+            alt="Support Orcasound"
             quality={100}
             layout="responsive"
             objectFit="contain"
@@ -108,7 +108,7 @@ const DonateOrcasound = (props: DonateOrcasoundProps) => {
         <ImageContainer>
           <Image
             src={props.donateVolunteersImage}
-            alt="Picture of Support Volunteers"
+            alt="Support Volunteers"
             quality={100}
             layout="responsive"
             objectFit="contain"

--- a/src/components/Donate/DonateOrcasound.tsx
+++ b/src/components/Donate/DonateOrcasound.tsx
@@ -60,7 +60,7 @@ const DonateOrcasound = (props: DonateOrcasoundProps) => {
         <ImageContainer>
           <Image
             src={props.donateOrcasoundImage}
-            alt="Picture of Donate to Orcasound"
+            alt="Picture of Support Orcasound"
             quality={100}
             layout="responsive"
             objectFit="contain"
@@ -93,7 +93,7 @@ const DonateOrcasound = (props: DonateOrcasoundProps) => {
               })
             }
           >
-            Donate
+            Support
           </Button>
         </Box>
       </DonateContainer>
@@ -108,7 +108,7 @@ const DonateOrcasound = (props: DonateOrcasoundProps) => {
         <ImageContainer>
           <Image
             src={props.donateVolunteersImage}
-            alt="Picture of Donate to Volunteers"
+            alt="Picture of Support Volunteers"
             quality={100}
             layout="responsive"
             objectFit="contain"

--- a/src/components/Donate/DonatePartners.jsx
+++ b/src/components/Donate/DonatePartners.jsx
@@ -148,7 +148,7 @@ const DonatePartners = () => {
             mb: { xs: '0.5rem', md: 0 },
           }}
         >
-          Support Our 501(c)3 Partners
+          Support our 501(c)3 Partners
         </Typography>
         <Typography sx={{ fontSize: { xs: '15px', md: '19px' } }}>
           Contribute to our partners to support on-going conservation, research,

--- a/src/components/Donate/DonatePartners.jsx
+++ b/src/components/Donate/DonatePartners.jsx
@@ -148,7 +148,7 @@ const DonatePartners = () => {
             mb: { xs: '0.5rem', md: 0 },
           }}
         >
-          Donate to our 501(c)3 Partners
+          Support Our 501(c)3 Partners
         </Typography>
         <Typography sx={{ fontSize: { xs: '15px', md: '19px' } }}>
           Contribute to our partners to support on-going conservation, research,

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -126,7 +126,7 @@ const navLinksLeftCol = [
     icon: '',
   },
   {
-    name: 'Donate',
+    name: 'Support',
     url: '/donate',
     icon: '',
   },
@@ -205,7 +205,7 @@ function Mobile() {
         <div>
           <Link href="/donate" passHref>
             <StyledTypography variant="h6" component="a">
-              Donate
+              Support
             </StyledTypography>
           </Link>
         </div>

--- a/src/pages/donate.jsx
+++ b/src/pages/donate.jsx
@@ -17,7 +17,7 @@ export const Donate = () => {
       </Head>
       <TopBanner
         bannerImg={topbanner}
-        pageTitle={`Donate`}
+        pageTitle={`Support`}
         pageDesc={`Help protect marine life like the Southern Resident Killer whales by donating today`}
         scrollToId={`donate`}
         imageFilter="brightness(0.8)"
@@ -35,10 +35,10 @@ export const Donate = () => {
         >
           <DonateOrcasound
             donateOrcasoundImage={donateOrcasoundImage}
-            donateOrcasoundTitle="Donate to Orcasound"
+            donateOrcasoundTitle="Support Orcasound"
             donateOrcasoundMessage="Help us build and maintain the technology to listen to orcas in the world."
             donateVolunteersImage={donateVolunteersImage}
-            donateVolunteersTitle="Donate to Volunteers"
+            donateVolunteersTitle="Support Volunteers"
             donateVolunteersMessage="Support those who keep the orcasound website and hydrophone nodes running."
           />
           <br />

--- a/src/pages/getinvolved.jsx
+++ b/src/pages/getinvolved.jsx
@@ -54,7 +54,7 @@ export const GetInvolved = () => {
   const InviteLinks = [
     { name: 'Volunteer', id: 'volunteer' },
     { name: 'Developers', id: 'for_developers' },
-    { name: 'Donate', id: 'donate' },
+    { name: 'Support', id: 'donate' },
   ]
 
   return (
@@ -518,7 +518,7 @@ export const GetInvolved = () => {
             fontWeight="600"
             mb="40px"
           >
-            Donate
+            Support
           </Typography>
           <Typography
             variant="p"
@@ -548,7 +548,7 @@ export const GetInvolved = () => {
           </Typography>
           <ActionButton
             link="/donate"
-            text="DONATE NOW"
+            text="SUPPORT NOW"
             onClick={() =>
               pushToDataLayer('cta_click', {
                 cta_text: 'Donate Now',

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -427,9 +427,9 @@ export const index = () => {
         </Grid>
 
         {/* Netlify badge for open source plan https://www.netlify.com/legal/open-source-policy */}
-        <a href="https://netlify.com">
+        <a href="https://www.netlify.com">
           <Image
-            src="https://netlify.com/img/global/badges/netlify-color-accent.svg"
+            src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg"
             alt="Deploys by Netlify"
             width="114"
             height="51"


### PR DESCRIPTION
Replace all user-visible 'Donate' text with 'Support' across buttons, CTAs, page titles, nav items, and section headings. Route paths, analytics payloads, component names, and third-party URLs are intentionally unchanged.

From https://github.com/orcasound/orcahome/issues/217