### PR TITLE
Refactor: Extract DonatePartners data to JSON, add README pointer and Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/donate-page-change.yml
+++ b/.github/ISSUE_TEMPLATE/donate-page-change.yml
@@ -1,8 +1,8 @@
 name: Donate page change
 description: Any change to the Donate page partner list, Orcasound support flow, or donation URLs.
-title: "[Donate page]: "
+title: '[Donate page]: '
 labels:
-  - "type: story"
+  - 'type: story'
 body:
   - type: markdown
     attributes:
@@ -57,4 +57,4 @@ body:
     attributes:
       label: Suggested assignee
       description: Optional. Brendan reviews and confirms at the next sprint planning.
-      placeholder: "Optional. Brendan assigns at planning."
+      placeholder: 'Optional. Brendan assigns at planning.'

--- a/.github/ISSUE_TEMPLATE/donate-page-change.yml
+++ b/.github/ISSUE_TEMPLATE/donate-page-change.yml
@@ -1,0 +1,60 @@
+name: Donate page change
+description: Any change to the Donate page partner list, Orcasound support flow, or donation URLs.
+title: "[Donate page]: "
+labels:
+  - "type: story"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a Donate page change. Two canonical files to know:
+
+        - Partner list data: `src/data/donatePartners.json`
+        - Orcasound support flow component: `src/components/Donate/DonateOrcasound.tsx`
+
+        See the Donate page data section of the README for the full convention.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What is the change and why is it needed? Cite the source (research finding, partner request, stakeholder direction, etc.).
+      placeholder: |
+        Example: Orca Network requested their donation URL update from /donate to /support. Confirmed via email from their development director 2026-05-18.
+    validations:
+      required: true
+
+  - type: textarea
+    id: change
+    attributes:
+      label: Proposed change
+      description: Specifically what fields change. If multiple partners, list each.
+      placeholder: |
+        Example:
+
+        Partner: Orca Network
+        Field: linkTo
+        From: https://www.orcanetwork.org/donate
+        To: https://www.orcanetwork.org/support
+
+        File to edit: src/data/donatePartners.json
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: verification
+    attributes:
+      label: Pre-merge verification checklist
+      options:
+        - label: Destination URL is live (HTTPS, 200 response, lands on a real donation page)
+        - label: Icon asset exists at the path in the icon field (or icon asset added in this PR)
+        - label: Description copy reviewed for accuracy and tone
+        - label: Smoke check confirms partner card renders correctly on deploy preview
+        - label: Smoke check confirms partner_link_click analytics event fires on link click
+
+  - type: input
+    id: assignee_suggestion
+    attributes:
+      label: Suggested assignee
+      description: Optional. Brendan reviews and confirms at the next sprint planning.
+      placeholder: "Optional. Brendan assigns at planning."

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
 
+## Donate page data
+
+The canonical list of Orcasound network partners shown on the Donate page lives at [`src/data/donatePartners.json`](src/data/donatePartners.json). Each partner has four fields:
+
+- `icon`: relative path to the partner logo asset under `public/`
+- `name`: partner organization name as displayed on the page
+- `description`: short copy displayed under the name
+- `linkTo`: destination URL when the user clicks Learn more
+
+The display component at [`src/components/Donate/DonatePartners.jsx`](src/components/Donate/DonatePartners.jsx) imports this data and renders mobile and desktop card variants. To add, remove, reorder, or update a partner, edit the JSON file and open a PR. The component does not need to change.
+
+For any Donate page change, use the [Donate page change issue template](.github/ISSUE_TEMPLATE/donate-page-change.yml) when filing the issue.
+
+The Orcasound support flow (Open Collective plus GitHub Sponsors links shown in the Support modal) currently lives inline at [`src/components/Donate/DonateOrcasound.tsx`](src/components/Donate/DonateOrcasound.tsx) and is tracked for a similar data extraction in a follow-up issue.
+
 # Contributing
 
 ``

--- a/src/components/Donate/DonatePartners.jsx
+++ b/src/components/Donate/DonatePartners.jsx
@@ -2,88 +2,8 @@ import { Box, Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import Image from 'next/image'
 
+import partners from '../../data/donatePartners.json'
 import { pushToDataLayer } from '../../utils/gtm'
-
-const partners = [
-  {
-    icon: '/images/donatePartners/center for whale research 1.svg',
-    name: 'The Center for Whale Research',
-    description:
-      "The Center for Whale Research helps the U.S. and Canadian governments with conservation and share whales'stories with the public.",
-    linkTo: 'https://www.whaleresearch.com/supportcwr',
-  },
-  {
-    icon: '/images/donatePartners/DeepGreenWildernes.svg',
-    name: 'Deep Green Wilderness',
-    description:
-      'Deep Green Wilderness provides public educational experiences to create ambassadors for marine animals and ecosystems.',
-    linkTo: 'https://www.deepgreenwilderness.com/donate',
-  },
-  {
-    icon: '/images/donatePartners/FOLKS-Orange.svg',
-    name: 'F.O.L.K.S',
-    description:
-      "F.O.L.K.S. provides visitors with education on the Salish Sea's diverse marine ecosystem.",
-    linkTo: 'https://folkssji.org/donate-today',
-  },
-  {
-    icon: '/images/donatePartners/orca-behavior-institute-logo-white.svg',
-    name: 'Orca Behavior Institute',
-    description:
-      'Orca Behavior Institute conducts non-invasive research on orcas and helps others learn how to protect these animals.',
-    linkTo: 'https://www.orcabehaviorinstitute.org/donate',
-  },
-  {
-    icon: '/images/donatePartners/OrcaConservancy.svg',
-    name: 'Orca Conservancy',
-    description:
-      'Orca Conservancy aims to preserve and protect Southern Resident killer whales.',
-    linkTo: 'https://www.orcaconservancy.org/donate',
-  },
-  {
-    icon: '/images/donatePartners/Orca-Network-Logo.svg',
-    name: 'Orca Network',
-    description:
-      'Orca Network provides education and a sighting report system on whales. You can volunteer and learn more at their Langley Whale Center.',
-    linkTo: 'https://www.orcanetwork.org/donate',
-  },
-  {
-    icon: '/images/donatePartners/port townsend marine research center.svg',
-    name: 'Port Townsend Marine Science Center',
-    description:
-      'Port Townsend Marine Science Center offers education, science, and volunteer opportunities on the Salish Sea.',
-    linkTo: 'https://ptmsc.org/donate/',
-  },
-  {
-    icon: '/images/donatePartners/Rectangle 887.svg',
-    name: 'Project SeaWolf',
-    description:
-      'Project SeaWolf works to promote and protect the biodiversity of the Pacific Northwest.',
-    linkTo: 'https://www.projectseawolf.org/How_to_Help.html',
-  },
-  {
-    icon: '/images/donatePartners/Sounds Action.svg',
-    name: 'Sound Action',
-    description:
-      'Sound Action is a watchdog group that ensures new developments in Washington state that may affect orcas and their habitats adhere to science and state law.',
-    linkTo:
-      'https://crm.bloomerang.co/HostedDonation?ApiKey=pub_d0480152-d37a-11ea-b90d-0a908e1cc508&WidgetId=808960',
-  },
-  {
-    icon: '/images/donatePartners/vashonNatureCenterLogo.svg',
-    name: 'Vashon Nature Center',
-    description:
-      'Vashon Nature Center helps volunteers conduct research on the plants and animals of the Vashon-Maury Islands and the Salish Sea.',
-    linkTo: 'https://vashonnaturecenter.org/donate/',
-  },
-  {
-    icon: '/images/donatePartners/TheWhaleTrail-LogoSpyhop_RGB.svg',
-    name: 'The Whale Trail ',
-    description:
-      'The Whale Trail identifies orca migration paths along the Salish Sea and Pacific Coast.',
-    linkTo: 'https://thewhaletrail.org/connect/donate/',
-  },
-]
 
 const TitleContainer = styled(Box)(({ theme }) => ({
   backgroundColor: '#1b2b7b',

--- a/src/data/donatePartners.json
+++ b/src/data/donatePartners.json
@@ -1,0 +1,68 @@
+[
+  {
+    "icon": "/images/donatePartners/center for whale research 1.svg",
+    "name": "The Center for Whale Research",
+    "description": "The Center for Whale Research helps the U.S. and Canadian governments with conservation and share whales'stories with the public.",
+    "linkTo": "https://www.whaleresearch.com/supportcwr"
+  },
+  {
+    "icon": "/images/donatePartners/DeepGreenWildernes.svg",
+    "name": "Deep Green Wilderness",
+    "description": "Deep Green Wilderness provides public educational experiences to create ambassadors for marine animals and ecosystems.",
+    "linkTo": "https://www.deepgreenwilderness.com/donate"
+  },
+  {
+    "icon": "/images/donatePartners/FOLKS-Orange.svg",
+    "name": "F.O.L.K.S",
+    "description": "F.O.L.K.S. provides visitors with education on the Salish Sea's diverse marine ecosystem.",
+    "linkTo": "https://folkssji.org/donate-today"
+  },
+  {
+    "icon": "/images/donatePartners/orca-behavior-institute-logo-white.svg",
+    "name": "Orca Behavior Institute",
+    "description": "Orca Behavior Institute conducts non-invasive research on orcas and helps others learn how to protect these animals.",
+    "linkTo": "https://www.orcabehaviorinstitute.org/donate"
+  },
+  {
+    "icon": "/images/donatePartners/OrcaConservancy.svg",
+    "name": "Orca Conservancy",
+    "description": "Orca Conservancy aims to preserve and protect Southern Resident killer whales.",
+    "linkTo": "https://www.orcaconservancy.org/donate"
+  },
+  {
+    "icon": "/images/donatePartners/Orca-Network-Logo.svg",
+    "name": "Orca Network",
+    "description": "Orca Network provides education and a sighting report system on whales. You can volunteer and learn more at their Langley Whale Center.",
+    "linkTo": "https://www.orcanetwork.org/donate"
+  },
+  {
+    "icon": "/images/donatePartners/port townsend marine research center.svg",
+    "name": "Port Townsend Marine Science Center",
+    "description": "Port Townsend Marine Science Center offers education, science, and volunteer opportunities on the Salish Sea.",
+    "linkTo": "https://ptmsc.org/donate/"
+  },
+  {
+    "icon": "/images/donatePartners/Rectangle 887.svg",
+    "name": "Project SeaWolf",
+    "description": "Project SeaWolf works to promote and protect the biodiversity of the Pacific Northwest.",
+    "linkTo": "https://www.projectseawolf.org/How_to_Help.html"
+  },
+  {
+    "icon": "/images/donatePartners/Sounds Action.svg",
+    "name": "Sound Action",
+    "description": "Sound Action is a watchdog group that ensures new developments in Washington state that may affect orcas and their habitats adhere to science and state law.",
+    "linkTo": "https://crm.bloomerang.co/HostedDonation?ApiKey=pub_d0480152-d37a-11ea-b90d-0a908e1cc508&WidgetId=808960"
+  },
+  {
+    "icon": "/images/donatePartners/vashonNatureCenterLogo.svg",
+    "name": "Vashon Nature Center",
+    "description": "Vashon Nature Center helps volunteers conduct research on the plants and animals of the Vashon-Maury Islands and the Salish Sea.",
+    "linkTo": "https://vashonnaturecenter.org/donate/"
+  },
+  {
+    "icon": "/images/donatePartners/TheWhaleTrail-LogoSpyhop_RGB.svg",
+    "name": "The Whale Trail ",
+    "description": "The Whale Trail identifies orca migration paths along the Salish Sea and Pacific Coast.",
+    "linkTo": "https://thewhaletrail.org/connect/donate/"
+  }
+]


### PR DESCRIPTION
Closes #264

## Summary

Pure refactor. No behavior or rendered output changes. Three things ship in one commit.

1. **Extract partner data to JSON.** New file `src/data/donatePartners.json` holds the eleven-partner array. `src/components/Donate/DonatePartners.jsx` imports from it. Data verbatim from the previous inline array, including the existing typo in The Center for Whale Research description (`whales'stories`) and the trailing space in `The Whale Trail `. Both are content-correction items for a separate ticket.
2. **Add a "Donate page data" section to README.md.** Explains where the canonical partner data lives, the four fields, and points to the Donate page change issue template. Also flags `DonateOrcasound.tsx` as a similar follow-up extraction target.
3. **Add `.github/ISSUE_TEMPLATE/donate-page-change.yml`.** GitHub Issue Form for any Donate page change. Auto-includes the canonical data file path, a structured change description, and a pre-merge verification checklist.

## Files changed

- `src/data/donatePartners.json` (new)
- `src/components/Donate/DonatePartners.jsx` (modified, partner array replaced with import)
- `README.md` (modified, new "Donate page data" section added before the Contributing heading)
- `.github/ISSUE_TEMPLATE/donate-page-change.yml` (new)

## Test plan

- [ ] CI passes (Test, Lint, Format, Build, Redirect rules, Header rules, Pages changed)
- [ ] Deploy preview Donate page renders eleven partner cards identical to current production, in the same order
- [ ] Each partner card destination URL clicks through to the expected donate page (smoke check)
- [ ] `partner_link_click` analytics event still fires on link click
- [ ] New "Donate page change" template appears in the GitHub New Issue picker after merge to main
- [ ] README "Donate page data" section renders correctly on the GitHub repo home page

## Out of scope

- Fixing the `whales'stories` typo or the trailing space in `The Whale Trail `. Refactor stays content-neutral; content fixes file separately.
- Extracting `DonateOrcasound.tsx` Open Collective plus GitHub Sponsors links to data. Same pattern would apply but the dialog mixes data with translated copy and image props in a way that needs a small design pass first. Logged as a follow-up in issue #264 and called out in the README.
- Headless CMS migration. This refactor is a step toward that work, not the work itself.

## Sprint disposition

Filed as part of Sprint 2 GitHub triage 2026-05-18. Sprint 2 placement TBD by Brendan.
