### PR TITLE
#272 feat: add interactive waveform playback to Call Catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-dom": "17.0.2",
         "react-scroll": "^1.8.4",
         "react-zoom-pan-pinch": "^3.7.0",
-        "use-sound": "^4.0.1"
+        "use-sound": "^4.0.1",
+        "wavesurfer.js": "^7.12.7"
       },
       "devDependencies": {
         "@types/node": "^16.11.22",
@@ -8073,6 +8074,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/wavesurfer.js": {
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.12.7.tgz",
+      "integrity": "sha512-TIe7hB6OCZysNOZ2cn2NR8Qpko22POWel6rauNcqOammFoH65NYQUM35unNLLMIlUMVYvjJ6w/TTl/G/m+w0nA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-dom": "17.0.2",
     "react-scroll": "^1.8.4",
     "react-zoom-pan-pinch": "^3.7.0",
-    "use-sound": "^4.0.1"
+    "use-sound": "^4.0.1",
+    "wavesurfer.js": "^7.12.7"
   },
   "devDependencies": {
     "@types/node": "^16.11.22",

--- a/src/components/Catalog/CatalogCallList.jsx
+++ b/src/components/Catalog/CatalogCallList.jsx
@@ -11,6 +11,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { pushToDataLayer } from '../../utils/gtm'
 import { CALLS } from './callsData'
 import { POD_KEY } from './constants'
+import WaveformPlayer from './WaveformPlayer'
 
 export { CALLS }
 
@@ -23,82 +24,53 @@ const PLAYER_ICON_SIZES = {
   downloadButton: { width: 24, height: 24, icon: 20 },
 }
 
-function clearAudioHandlers(audio) {
-  audio.ontimeupdate = null
-  audio.onended = null
-}
-
 export default function CatalogCallList({ activePod }) {
-  const [currentlyPlaying, setCurrentlyPlaying] = useState(null)
+  const [activeCallId, setActiveCallId] = useState(null)
+  const [isPlaying, setIsPlaying] = useState(false)
   const [playbackTime, setPlaybackTime] = useState(0)
   const [isMuted, setIsMuted] = useState(false)
-  const audioRef = useRef(null)
+  const waveSurferRef = useRef(null)
   const [expandedId, setExpandedId] = useState(null)
   const [page, setPage] = useState(1)
 
-  const handlePlay = useCallback(
+  const handlePlayPause = useCallback(
     (call) => {
       if (!call.audio) return
 
-      if (audioRef.current) {
-        audioRef.current.pause()
-        clearAudioHandlers(audioRef.current)
-        audioRef.current.currentTime = 0
-      }
-
-      const audio = new Audio(call.audio)
-      audio.muted = isMuted
-      audioRef.current = audio
-      audio.ontimeupdate = () => {
-        if (audioRef.current === audio) setPlaybackTime(audio.currentTime)
-      }
-      audio.onended = () => {
-        if (audioRef.current !== audio) return
-        clearAudioHandlers(audio)
-        audioRef.current = null
-        setCurrentlyPlaying(null)
-        setPlaybackTime(0)
-      }
-
-      setPlaybackTime(0)
-      audio
-        .play()
-        .then(() => {
-          if (audioRef.current !== audio) return
-          setCurrentlyPlaying(call.id)
-          pushToDataLayer('audio_play', {
-            call_name: call.id,
-            section: 'call_catalog',
+      if (activeCallId === call.id) {
+        if (isPlaying) {
+          waveSurferRef.current?.pause()
+          setIsPlaying(false)
+        } else {
+          setIsPlaying(true)
+          waveSurferRef.current?.play().catch(() => {
+            setIsPlaying(false)
           })
-        })
-        .catch(() => {
-          if (audioRef.current !== audio) return
-          clearAudioHandlers(audio)
-          audioRef.current = null
-          setCurrentlyPlaying(null)
-          setPlaybackTime(0)
-        })
+        }
+        return
+      }
+
+      waveSurferRef.current?.stop()
+      waveSurferRef.current = null
+      setActiveCallId(call.id)
+      setIsPlaying(true)
+      setPlaybackTime(0)
     },
-    [isMuted]
+    [activeCallId, isPlaying]
   )
 
   const handleStop = useCallback(() => {
-    if (audioRef.current) {
-      audioRef.current.pause()
-      clearAudioHandlers(audioRef.current)
-      audioRef.current.currentTime = 0
-      audioRef.current = null
-    }
-    setCurrentlyPlaying(null)
+    waveSurferRef.current?.stop()
+    waveSurferRef.current = null
+    setActiveCallId(null)
+    setIsPlaying(false)
     setPlaybackTime(0)
   }, [])
 
   const handleToggleMute = useCallback(() => {
     setIsMuted((currentMuted) => {
       const nextMuted = !currentMuted
-      if (audioRef.current) {
-        audioRef.current.muted = nextMuted
-      }
+      waveSurferRef.current?.setMuted(nextMuted)
       return nextMuted
     })
   }, [])
@@ -106,14 +78,14 @@ export default function CatalogCallList({ activePod }) {
   const handleToggle = useCallback(
     (callId) => {
       if (expandedId === callId) {
-        if (currentlyPlaying === callId) handleStop()
+        if (activeCallId === callId) handleStop()
         setExpandedId(null)
       } else {
-        if (currentlyPlaying !== null) handleStop()
+        if (activeCallId !== null) handleStop()
         setExpandedId(callId)
       }
     },
-    [expandedId, currentlyPlaying, handleStop]
+    [expandedId, activeCallId, handleStop]
   )
 
   const filteredCalls = useMemo(() => {
@@ -129,30 +101,28 @@ export default function CatalogCallList({ activePod }) {
   }, [filteredCalls, page])
 
   useEffect(() => {
+    handleStop()
     setPage(1)
-  }, [activePod])
+  }, [activePod, handleStop])
 
   useEffect(() => {
     return () => {
-      if (audioRef.current) {
-        audioRef.current.pause()
-        clearAudioHandlers(audioRef.current)
-        audioRef.current = null
-      }
+      waveSurferRef.current?.stop()
+      waveSurferRef.current = null
     }
   }, [])
 
   useEffect(() => {
     const visibleCallIds = new Set(pagedCalls.map((call) => call.id))
 
-    if (currentlyPlaying && !visibleCallIds.has(currentlyPlaying)) {
+    if (activeCallId && !visibleCallIds.has(activeCallId)) {
       handleStop()
     }
 
     if (expandedId && !visibleCallIds.has(expandedId)) {
       setExpandedId(null)
     }
-  }, [pagedCalls, currentlyPlaying, expandedId, handleStop])
+  }, [pagedCalls, activeCallId, expandedId, handleStop])
 
   return (
     <Box>
@@ -161,13 +131,37 @@ export default function CatalogCallList({ activePod }) {
         <CallRow
           key={call.id}
           call={call}
-          isPlaying={currentlyPlaying === call.id}
+          isActive={activeCallId === call.id}
+          isPlaying={activeCallId === call.id && isPlaying}
           expanded={expandedId === call.id}
-          playbackTime={currentlyPlaying === call.id ? playbackTime : 0}
+          playbackTime={activeCallId === call.id ? playbackTime : 0}
           isMuted={isMuted}
           onToggle={() => handleToggle(call.id)}
-          onPlay={() => handlePlay(call)}
+          onPlayPause={() => handlePlayPause(call)}
           onStop={handleStop}
+          onWaveSurferReady={(waveSurfer) => {
+            if (activeCallId === call.id) {
+              waveSurferRef.current = waveSurfer
+              waveSurfer?.setMuted(isMuted)
+            }
+          }}
+          onPlaybackStarted={() => {
+            if (activeCallId !== call.id) return
+            setIsPlaying(true)
+            pushToDataLayer('audio_play', {
+              call_name: call.id,
+              section: 'call_catalog',
+            })
+          }}
+          onPlaybackPaused={() => {
+            if (activeCallId === call.id) setIsPlaying(false)
+          }}
+          onPlaybackTimeChange={(time) => {
+            if (activeCallId === call.id) setPlaybackTime(time)
+          }}
+          onPlaybackError={() => {
+            if (activeCallId === call.id) handleStop()
+          }}
           onToggleMute={handleToggleMute}
           downloadPath={call.audio}
         />
@@ -177,7 +171,10 @@ export default function CatalogCallList({ activePod }) {
           <Pagination
             count={pageCount}
             page={page}
-            onChange={(_, value) => setPage(value)}
+            onChange={(_, value) => {
+              handleStop()
+              setPage(value)
+            }}
             shape="rounded"
           />
         </Box>
@@ -188,13 +185,19 @@ export default function CatalogCallList({ activePod }) {
 
 function CallRow({
   call,
+  isActive,
   isPlaying,
   expanded,
   playbackTime,
   isMuted,
   onToggle,
-  onPlay,
+  onPlayPause,
   onStop,
+  onWaveSurferReady,
+  onPlaybackStarted,
+  onPlaybackPaused,
+  onPlaybackTimeChange,
+  onPlaybackError,
   onToggleMute,
   downloadPath,
 }) {
@@ -261,11 +264,7 @@ function CallRow({
             <IconButton
               onClick={(event) => {
                 event.stopPropagation()
-                if (isPlaying) {
-                  onStop()
-                } else {
-                  onPlay()
-                }
+                onPlayPause()
               }}
               aria-label={`${isPlaying ? 'Pause' : 'Play'} ${callLabel}`}
               sx={{
@@ -392,16 +391,18 @@ function CallRow({
               }}
             >
               <Box
-                component="img"
-                src={waveformSrc}
-                alt=""
-                aria-hidden="true"
-                sx={{
-                  display: 'block',
-                  width: '100%',
-                  height: '100%',
-                  objectFit: 'contain',
-                }}
+                component={isActive ? WaveformPlayer : StaticWaveform}
+                audioSrc={call.audio}
+                waveformSrc={waveformSrc}
+                isActive={isActive}
+                shouldPlay={isPlaying}
+                isMuted={isMuted}
+                onReady={onWaveSurferReady}
+                onPlaybackStarted={onPlaybackStarted}
+                onPlaybackPaused={onPlaybackPaused}
+                onPlaybackTimeChange={onPlaybackTimeChange}
+                onFinish={onStop}
+                onError={onPlaybackError}
               />
             </Box>
 
@@ -503,6 +504,23 @@ function CallRow({
       )}
       <Divider sx={{ borderColor: '#000' }} />
     </>
+  )
+}
+
+function StaticWaveform({ waveformSrc }) {
+  return (
+    <Box
+      component="img"
+      src={waveformSrc}
+      alt=""
+      aria-hidden="true"
+      sx={{
+        display: 'block',
+        width: '100%',
+        height: '100%',
+        objectFit: 'contain',
+      }}
+    />
   )
 }
 

--- a/src/components/Catalog/WaveformPlayer.jsx
+++ b/src/components/Catalog/WaveformPlayer.jsx
@@ -1,0 +1,192 @@
+import { Box } from '@mui/material'
+import React, { useEffect, useRef, useState } from 'react'
+
+export default function WaveformPlayer({
+  audioSrc,
+  waveformSrc,
+  shouldPlay,
+  isMuted,
+  onReady,
+  onPlaybackStarted,
+  onPlaybackPaused,
+  onPlaybackTimeChange,
+  onFinish,
+  onError,
+}) {
+  const containerRef = useRef(null)
+  const waveSurferRef = useRef(null)
+  const shouldPlayRef = useRef(shouldPlay)
+  const isMutedRef = useRef(isMuted)
+  const callbacksRef = useRef({
+    onReady,
+    onPlaybackStarted,
+    onPlaybackPaused,
+    onPlaybackTimeChange,
+    onFinish,
+    onError,
+  })
+  const [isReady, setIsReady] = useState(false)
+  const [hasError, setHasError] = useState(false)
+
+  useEffect(() => {
+    shouldPlayRef.current = shouldPlay
+  }, [shouldPlay])
+
+  useEffect(() => {
+    isMutedRef.current = isMuted
+  }, [isMuted])
+
+  useEffect(() => {
+    callbacksRef.current = {
+      onReady,
+      onPlaybackStarted,
+      onPlaybackPaused,
+      onPlaybackTimeChange,
+      onFinish,
+      onError,
+    }
+  }, [
+    onError,
+    onFinish,
+    onPlaybackPaused,
+    onPlaybackStarted,
+    onPlaybackTimeChange,
+    onReady,
+  ])
+
+  useEffect(() => {
+    let isCancelled = false
+    let subscriptions = []
+
+    import('wavesurfer.js')
+      .then(({ default: WaveSurfer }) => {
+        if (isCancelled || !containerRef.current) return
+
+        const waveSurfer = WaveSurfer.create({
+          container: containerRef.current,
+          url: audioSrc,
+          height: 64,
+          waveColor: '#9a9a9a',
+          progressColor: '#000',
+          cursorColor: '#000',
+          cursorWidth: 2,
+          barWidth: 2.5,
+          barGap: 1.5,
+          barRadius: 1,
+          fillParent: true,
+          interact: true,
+          dragToSeek: true,
+          normalize: true,
+        })
+
+        waveSurferRef.current = waveSurfer
+        waveSurfer.setMuted(isMutedRef.current)
+        callbacksRef.current.onReady(waveSurfer)
+
+        subscriptions = [
+          waveSurfer.on('ready', () => {
+            if (isCancelled) return
+            setIsReady(true)
+            setHasError(false)
+            if (shouldPlayRef.current) {
+              waveSurfer.play().catch(() => {
+                if (!isCancelled) callbacksRef.current.onError()
+              })
+            }
+          }),
+          waveSurfer.on('play', () => {
+            if (!isCancelled) callbacksRef.current.onPlaybackStarted()
+          }),
+          waveSurfer.on('pause', () => {
+            if (!isCancelled) callbacksRef.current.onPlaybackPaused()
+          }),
+          waveSurfer.on('finish', () => {
+            if (!isCancelled) callbacksRef.current.onFinish()
+          }),
+          waveSurfer.on('timeupdate', (currentTime) => {
+            if (!isCancelled)
+              callbacksRef.current.onPlaybackTimeChange(currentTime)
+          }),
+          waveSurfer.on('seeking', (currentTime) => {
+            if (!isCancelled)
+              callbacksRef.current.onPlaybackTimeChange(currentTime)
+          }),
+          waveSurfer.on('error', () => {
+            if (isCancelled) return
+            setHasError(true)
+            callbacksRef.current.onError()
+          }),
+        ]
+      })
+      .catch(() => {
+        if (isCancelled) return
+        setHasError(true)
+        callbacksRef.current.onError()
+      })
+
+    return () => {
+      isCancelled = true
+      subscriptions.forEach((unsubscribe) => unsubscribe())
+      if (waveSurferRef.current) {
+        waveSurferRef.current.stop()
+        waveSurferRef.current.destroy()
+        waveSurferRef.current = null
+      }
+      callbacksRef.current.onReady(null)
+    }
+  }, [audioSrc])
+
+  useEffect(() => {
+    if (!waveSurferRef.current || !isReady || hasError) return
+
+    waveSurferRef.current.setMuted(isMuted)
+  }, [hasError, isMuted, isReady])
+
+  useEffect(() => {
+    if (!waveSurferRef.current || !isReady || hasError) return
+
+    if (shouldPlay) {
+      waveSurferRef.current.play().catch(() => {
+        callbacksRef.current.onError()
+      })
+    } else {
+      waveSurferRef.current.pause()
+    }
+  }, [hasError, isReady, shouldPlay])
+
+  return (
+    <Box
+      onClick={(event) => event.stopPropagation()}
+      sx={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <Box
+        component="img"
+        src={waveformSrc}
+        alt=""
+        aria-hidden="true"
+        sx={{
+          display: isReady && !hasError ? 'none' : 'block',
+          width: '100%',
+          height: '100%',
+          objectFit: 'contain',
+        }}
+      />
+      <Box
+        ref={containerRef}
+        aria-hidden={hasError ? 'true' : undefined}
+        sx={{
+          display: hasError ? 'none' : 'block',
+          position: isReady ? 'static' : 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          cursor: 'pointer',
+        }}
+      />
+    </Box>
+  )
+}


### PR DESCRIPTION
### Summary
  - Adds an interactive WaveSurfer.js player for active Call Catalog entries
  - Syncs waveform playback with play, pause, stop, mute, pagination, and pod changes
  - Keeps the existing static waveform PNG visible as the fallback/loading state
  - Tracks audio playback events from the new waveform-backed player

Closes #272 