### PR TITLE
fix: restore Hacker Hall of Fame image layout under Next 16 (#301)

### DIFF
--- a/src/pages/hacker-hall-of-fame.jsx
+++ b/src/pages/hacker-hall-of-fame.jsx
@@ -102,7 +102,6 @@ const HackerHallOfFame = () => {
         {/* first paragraph */}
         <Box
           sx={{
-            maxHeight: '10em',
             width: '100%',
             display: 'flex',
             alignItems: 'center',
@@ -135,12 +134,12 @@ const HackerHallOfFame = () => {
         {/*Second paragraph */}
         <Box
           sx={{
-            height: '10em',
             width: '100%',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
             color: 'black',
+            mt: 6,
           }}
         >
           <Typography
@@ -148,17 +147,10 @@ const HackerHallOfFame = () => {
               fontSize: '20px',
               fontWeight: '500',
               lineHeight: '140%',
-              mt: 10,
-              /*iphone  formatting */
-              '@media (min-width:375px) and (max-width:500px)': {
-                mt: 60,
-              },
-
               /*ipad */
               '@media (min-width:768px) and (max-width:1200px)': {
                 fontSize: 'x-large',
                 width: '80%',
-                mt: 50,
               },
             }}
           >
@@ -204,36 +196,23 @@ const HackerHallOfFame = () => {
           sx={{
             position: 'relative',
             width: '100%',
-            height: '25em',
             display: 'flex',
             flexDirection: 'column',
 
-            mt: 10,
-
-            /*iphone  formatting */
-            '@media (min-width:375px) and (max-width:500px)': {
-              mt: 47,
-            },
-            /*ipad */
-            '@media (min-width:768px) and (max-width:1200px)': {
-              fontSize: 'x-large',
-              mt: 50,
-            },
+            my: 6,
           }}
         >
           <Image
             src={hackathon}
             alt="Orcasound at a democracy lab hackathon in Seattle"
+            width={573}
+            height={368}
             style={{
+              width: '100%',
+              height: 'auto',
+              maxHeight: '368px',
               objectFit: 'cover',
-              width: '795px',
-              height: '444px',
-              top: '1331px',
-              left: '320px',
-              angle: '0 deg',
-              opacity: 1,
               borderRadius: '20px',
-              mt: 20,
             }}
           />
           <Typography variant="caption" sx={{ color: 'text.secondary' }}>
@@ -245,7 +224,6 @@ const HackerHallOfFame = () => {
         {/*Third paragraph after first image */}
         <Box
           sx={{
-            maxHeight: '10em',
             width: '100%',
             display: 'flex',
             alignItems: 'center',
@@ -260,15 +238,10 @@ const HackerHallOfFame = () => {
               fontWeight: '500',
               lineHeight: '140%',
 
-              /*iphone  formatting */
-              '@media (min-width:375px) and (max-width:500px)': {
-                mt: 5,
-              },
               /*ipad */
               '@media (min-width:768px) and (max-width:1200px)': {
                 fontSize: 'x-large',
                 width: '80%',
-                mt: -20,
               },
             }}
           >
@@ -1805,8 +1778,6 @@ const HackerHallOfFame = () => {
             display: 'grid',
             gridTemplateColumns: '100%',
             width: '30%',
-
-            height: '20em',
             '@media (min-width:375px) and (max-width:500px)': {
               width: '90%',
               mb: 6,
@@ -1814,8 +1785,6 @@ const HackerHallOfFame = () => {
             '@media (min-width:768px) and (max-width:1200px)': {
               width: '40%',
               ml: 3,
-              height: '21em',
-
               mb: 3,
             },
           }}
@@ -1823,10 +1792,11 @@ const HackerHallOfFame = () => {
           <Image
             src={hackCollab}
             alt="Erika facilitating an early discussion of machine learning and the orca data repository"
-            fill
+            width={413}
+            height={271}
             style={{
-              objectFit: 'cover',
-              width: '50%',
+              width: '100%',
+              height: 'auto',
               borderRadius: '20px',
             }}
           />
@@ -1842,16 +1812,11 @@ const HackerHallOfFame = () => {
             gridTemplateColumns: '100%',
 
             width: '30%',
-            height: '19em',
-            mt: -2,
             '@media (min-width:375px) and (max-width:500px)': {
               width: '90%',
-              mt: -8,
             },
             '@media (min-width:768px) and (max-width:1200px)': {
               width: '40%',
-              height: '21em',
-              mt: -3,
               mr: 3,
             },
           }}
@@ -1859,10 +1824,11 @@ const HackerHallOfFame = () => {
           <Image
             src={hackVal}
             alt="Val working on the Orcanode software and hardware."
-            fill
+            width={413}
+            height={271}
             style={{
-              objectFit: 'contain',
-              width: '50%',
+              width: '100%',
+              height: 'auto',
               borderRadius: '20px',
             }}
           />


### PR DESCRIPTION
## Summary

Fixes #301 — the Hacker Hall of Fame layout broke after the Next 16 upgrade (#273).

The root cause is pre-existing markup from #267 that only rendered correctly under **Next 12's lenient legacy `next/image`**:
- the two bottom images used `fill` together with `style.width` (a combination Next 16 rejects), and
- every content block (paragraphs + images) was wrapped in a **fixed-height box** (`height`/`maxHeight: '10em' / '25em' / '20em' / '19em'`) whose real content was taller, so it overflowed — then got nudged back into place with **magic-number margins** (`mt: 50`, `mt: -20`, `mt: -8`, `mt: -3`, …).

Next 16's modern `next/image` removes the legacy sizing wrapper and applies styles directly to the `<img>`, which exposed all of that as floating/oversized images and overlapping text. (Production looked "ok" only because production builds skip the dev-only `fill` validation.)

## Changes (all in `src/pages/hacker-hall-of-fame.jsx`)

- **Bottom images (Erika / Val):** replace `fill` + `style.width` with explicit `width`/`height` props and responsive `width:100%; height:auto`; drop the fixed box heights and the negative-margin alignment hacks. The two equal-sized, same-source images now align naturally via the `Stack`'s `alignItems: center`.
- **Mid-page hackathon image:** replace the hardcoded `795×444` + leftover Figma props (`top`/`left`/`angle`/`mt`) with `width={573} height={368}` and `width:100%; height:auto; maxHeight:368px; objectFit:cover`, reproducing the deploy-preview-290 banner at every width.
- **Surrounding text/image boxes:** remove the fixed `height`/`maxHeight` so each box sizes to its content, and replace the per-breakpoint magic-number margins with a single consistent vertical rhythm.

## Verification

Measured/screenshotted at **500 / 900 / 1000 / 1280px**:

- [x] No bottom/contributor images floating into the hero area
- [x] No image overlapping the text above or below it
- [x] Mid-page banner sizing matches the deploy-preview-290 reference (732×368 on desktop, scales down on mobile)
- [x] Symmetric spacing around images at all breakpoints
- [x] `npm run lint` passes
- [x] `npm run format:check` passes

## Related
- Caused by latent markup in #267, surfaced by the Next 16 upgrade in #273
- Deploy preview #290 used as the visual reference