### PR TITLE
#291 Refactor Call Catalog into single-responsibility modules

### DIFF
--- a/src/components/Catalog/CallCatalogSection.jsx
+++ b/src/components/Catalog/CallCatalogSection.jsx
@@ -1,0 +1,54 @@
+import { Typography } from '@mui/material'
+import { useState } from 'react'
+
+import { CALLS } from './callsData'
+import CatalogCallList from './CatalogCallList'
+import PodFilter from './PodFilter'
+
+export default function CallCatalogSection() {
+  const [activePod, setActivePod] = useState('All Calls')
+
+  return (
+    <>
+      {/* Section title */}
+      <Typography
+        variant="h2"
+        sx={{
+          fontFamily: 'Montserrat',
+          fontWeight: 500,
+          fontSize: { xs: '24px', md: '38px' },
+          textAlign: 'center',
+          mb: 3,
+        }}
+      >
+        Southern Resident Killer Whales Call Catalog
+      </Typography>
+
+      {/* Description */}
+      <Typography
+        sx={{
+          fontFamily: 'Mukta',
+          fontWeight: 400,
+          fontSize: '17px',
+          lineHeight: '28px',
+          maxWidth: '939px',
+          mx: 'auto',
+          mb: 5,
+        }}
+      >
+        Orcasound maintains an online catalog of the SRKW calls (built by Val
+        Veirs and his students at Colorado College, based on the Osborne-Ford
+        tape, March 1981, and the call classification of Ford, 1987). You can
+        browse {CALLS.length} Ford call entries and variants recorded throughout
+        the habitat of J, K, and L pod, with available audio, generated waveform
+        images, color spectrograms, and Ford catalog spectrograms.
+      </Typography>
+
+      {/* Pod filter tabs */}
+      <PodFilter activePod={activePod} onSelect={setActivePod} />
+
+      {/* Call list */}
+      <CatalogCallList key={activePod} activePod={activePod} />
+    </>
+  )
+}

--- a/src/components/Catalog/CallRow.jsx
+++ b/src/components/Catalog/CallRow.jsx
@@ -1,0 +1,349 @@
+import DownloadIcon from '@mui/icons-material/Download'
+import ExpandMoreOutlinedIcon from '@mui/icons-material/ExpandMoreOutlined'
+import PauseIcon from '@mui/icons-material/Pause'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import VolumeOffIcon from '@mui/icons-material/VolumeOff'
+import VolumeUpIcon from '@mui/icons-material/VolumeUp'
+import { Box, Divider, IconButton, Typography } from '@mui/material'
+import Image from 'next/image'
+
+import { pushToDataLayer } from '../../utils/gtm'
+import { formatDuration, formatPlaybackTime } from './formatTime'
+import SpectrogramPanel from './SpectrogramPanel'
+import StaticWaveform from './StaticWaveform'
+import WaveformPlayer from './WaveformPlayer'
+
+const PLAYER_ICON_SIZES = {
+  playButton: { width: 27, height: 26, icon: 30, pauseIcon: 24 },
+  toggleButton: { width: 34, height: 34, icon: 34 },
+  volumeButton: { width: 24, height: 24, icon: 20 },
+  downloadButton: { width: 24, height: 24, icon: 20 },
+}
+
+export default function CallRow({
+  call,
+  isActive,
+  isPlaying,
+  expanded,
+  playbackTime,
+  isMuted,
+  onToggle,
+  onPlayPause,
+  onStop,
+  onWaveSurferReady,
+  onPlaybackStarted,
+  onPlaybackPaused,
+  onPlaybackTimeChange,
+  onPlaybackError,
+  onToggleMute,
+  downloadPath,
+}) {
+  const hasAudio = !!call.audio
+  const callLabel = call.label ?? call.id
+  const thumbnailSrc = call.colorSpec
+  const waveformSrc = call.waveform
+  const duration = call.duration ?? 0
+
+  return (
+    <>
+      <Box
+        onClick={onToggle}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          py: 2,
+          gap: { xs: 1.25, md: 2 },
+          minHeight: '100px',
+          flexWrap: { xs: 'wrap', md: 'nowrap' },
+          pl: { md: '33px' },
+          pr: { md: '31px' },
+          cursor: 'pointer',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            flex: { xs: '1 1 100%', md: '0 0 auto' },
+            flexShrink: 0,
+          }}
+        >
+          {/* Spectrogram thumbnail */}
+          <Box
+            sx={{
+              width: 75,
+              height: 75,
+              flexShrink: 0,
+              background: thumbnailSrc ? '#f0f0f0' : 'transparent',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderRadius: 1,
+              overflow: 'hidden',
+              border: 'none',
+              boxSizing: 'border-box',
+            }}
+          >
+            {thumbnailSrc ? (
+              <Image
+                src={thumbnailSrc}
+                alt={`Spectrogram for ${callLabel}`}
+                width={75}
+                height={75}
+                style={{
+                  objectFit: 'cover',
+                  maxWidth: '100%',
+                  height: 'auto',
+                }}
+              />
+            ) : null}
+          </Box>
+
+          {/* Play / Pause button */}
+          {hasAudio && (
+            <IconButton
+              onClick={(event) => {
+                event.stopPropagation()
+                onPlayPause()
+              }}
+              aria-label={`${isPlaying ? 'Pause' : 'Play'} ${callLabel}`}
+              sx={{
+                bgcolor: '#fff',
+                borderRadius: '2px',
+                width: PLAYER_ICON_SIZES.playButton.width,
+                height: PLAYER_ICON_SIZES.playButton.height,
+                padding: 0,
+                flexShrink: 0,
+                ml: { xs: 1.25, md: '37px' },
+              }}
+            >
+              {isPlaying ? (
+                <PauseIcon
+                  sx={{
+                    color: '#000',
+                    fontSize: PLAYER_ICON_SIZES.playButton.pauseIcon,
+                  }}
+                />
+              ) : (
+                <PlayArrowIcon
+                  sx={{
+                    color: '#000',
+                    fontSize: PLAYER_ICON_SIZES.playButton.icon,
+                  }}
+                />
+              )}
+            </IconButton>
+          )}
+          {!hasAudio && (
+            <Box
+              aria-hidden="true"
+              sx={{
+                width: PLAYER_ICON_SIZES.playButton.width,
+                height: PLAYER_ICON_SIZES.playButton.height,
+                flexShrink: 0,
+                ml: { xs: 1.25, md: '37px' },
+              }}
+            />
+          )}
+
+          {/* Call ID */}
+          <Box
+            sx={{
+              width: { xs: 'auto', md: 260 },
+              minWidth: { xs: 150, md: 0 },
+              ml: { xs: 1.25, md: '34px' },
+              flexShrink: 0,
+            }}
+          >
+            <Box>
+              <Typography
+                sx={{
+                  fontFamily: 'Montserrat',
+                  fontWeight: 700,
+                  fontSize: '22px',
+                  lineHeight: 1.2,
+                }}
+              >
+                {callLabel}
+              </Typography>
+            </Box>
+          </Box>
+
+          {/* Expand toggle */}
+          <IconButton
+            onClick={(event) => {
+              event.stopPropagation()
+              onToggle()
+            }}
+            aria-label={`${expanded ? 'Collapse' : 'Expand'} ${callLabel}`}
+            sx={{
+              width: PLAYER_ICON_SIZES.toggleButton.width,
+              height: PLAYER_ICON_SIZES.toggleButton.height,
+              p: 0,
+              flexShrink: 0,
+              ml: { xs: 1.25, md: '12px' },
+            }}
+          >
+            <ExpandMoreOutlinedIcon
+              sx={{
+                color: '#000',
+                fontSize: PLAYER_ICON_SIZES.toggleButton.icon,
+                transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                transition: 'transform 160ms ease',
+              }}
+            />
+          </IconButton>
+        </Box>
+
+        {hasAudio && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              flex: { xs: '1 1 100%', md: '0 0 auto' },
+              flexShrink: 0,
+              ml: { md: 'auto' },
+            }}
+          >
+            {/* Timestamp */}
+            <Typography
+              sx={{
+                fontFamily: 'Montserrat',
+                fontWeight: 400,
+                fontSize: { xs: '14px', md: '18px' },
+                lineHeight: 1,
+                width: { xs: 'auto', md: 96 },
+                textAlign: { xs: 'left', md: 'right' },
+                flexShrink: 0,
+              }}
+            >
+              {formatPlaybackTime(playbackTime)}/{formatDuration(duration)}
+            </Typography>
+
+            {/* Waveform strip from the audio file */}
+            <Box
+              sx={{
+                width: { xs: 'min(48vw, 220px)', md: 295 },
+                height: 64,
+                flexShrink: 0,
+                ml: { xs: 1.25, md: '27px' },
+              }}
+            >
+              <Box
+                component={isActive ? WaveformPlayer : StaticWaveform}
+                audioSrc={call.audio}
+                waveformSrc={waveformSrc}
+                isActive={isActive}
+                shouldPlay={isPlaying}
+                isMuted={isMuted}
+                onReady={onWaveSurferReady}
+                onPlaybackStarted={onPlaybackStarted}
+                onPlaybackPaused={onPlaybackPaused}
+                onPlaybackTimeChange={onPlaybackTimeChange}
+                onFinish={onStop}
+                onError={onPlaybackError}
+              />
+            </Box>
+
+            <IconButton
+              onClick={(event) => {
+                event.stopPropagation()
+                onToggleMute()
+              }}
+              aria-label={`${isMuted ? 'Unmute' : 'Mute'} ${callLabel}`}
+              sx={{
+                width: PLAYER_ICON_SIZES.volumeButton.width,
+                height: PLAYER_ICON_SIZES.volumeButton.height,
+                p: 0,
+                flexShrink: 0,
+                ml: { xs: 1.25, md: '33px' },
+              }}
+            >
+              {isMuted ? (
+                <VolumeOffIcon
+                  sx={{
+                    color: '#000',
+                    fontSize: PLAYER_ICON_SIZES.volumeButton.icon,
+                  }}
+                />
+              ) : (
+                <VolumeUpIcon
+                  sx={{
+                    color: '#000',
+                    fontSize: PLAYER_ICON_SIZES.volumeButton.icon,
+                  }}
+                />
+              )}
+            </IconButton>
+
+            {/* Download */}
+            <IconButton
+              component="a"
+              href={downloadPath}
+              download={`${callLabel}.mp3`}
+              aria-label={`Download ${callLabel}`}
+              sx={{
+                width: PLAYER_ICON_SIZES.downloadButton.width,
+                height: PLAYER_ICON_SIZES.downloadButton.height,
+                p: 0,
+                flexShrink: 0,
+                ml: { xs: 1.25, md: '16px' },
+              }}
+              onClick={(event) => {
+                event.stopPropagation()
+                pushToDataLayer('download_click', {
+                  call_name: call.id,
+                  section: 'call_catalog',
+                })
+              }}
+            >
+              <DownloadIcon
+                sx={{
+                  color: '#000',
+                  fontSize: PLAYER_ICON_SIZES.downloadButton.icon,
+                }}
+              />
+            </IconButton>
+          </Box>
+        )}
+      </Box>
+      {expanded && (
+        <Box
+          sx={{
+            width: '100%',
+            mx: 'auto',
+            px: { xs: 2, md: 0 },
+            pl: { md: '145px' },
+            pb: 3,
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              gap: { xs: 2, md: '66px' },
+              justifyContent: 'center',
+              alignItems: 'center',
+              flexWrap: 'wrap',
+              width: { xs: '100%', md: 'fit-content' },
+              maxWidth: '100%',
+            }}
+          >
+            <SpectrogramPanel
+              src={call.colorSpec}
+              alt={`Color spectrogram for ${callLabel}`}
+              maxWidth={432}
+            />
+            <SpectrogramPanel
+              src={call.bwSpec}
+              alt={`Ford catalog spectrogram for ${callLabel}`}
+              maxWidth={434}
+            />
+          </Box>
+        </Box>
+      )}
+      <Divider sx={{ borderColor: '#000' }} />
+    </>
+  )
+}

--- a/src/components/Catalog/CatalogCallList.jsx
+++ b/src/components/Catalog/CatalogCallList.jsx
@@ -1,79 +1,30 @@
-import DownloadIcon from '@mui/icons-material/Download'
-import ExpandMoreOutlinedIcon from '@mui/icons-material/ExpandMoreOutlined'
-import PauseIcon from '@mui/icons-material/Pause'
-import PlayArrowIcon from '@mui/icons-material/PlayArrow'
-import VolumeOffIcon from '@mui/icons-material/VolumeOff'
-import VolumeUpIcon from '@mui/icons-material/VolumeUp'
-import { Box, Divider, IconButton, Pagination, Typography } from '@mui/material'
-import Image from 'next/image'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Box, Divider, Pagination } from '@mui/material'
+import { useCallback, useMemo, useState } from 'react'
 
-import { pushToDataLayer } from '../../utils/gtm'
+import CallRow from './CallRow'
 import { CALLS } from './callsData'
 import { POD_KEY } from './constants'
-import WaveformPlayer from './WaveformPlayer'
-
-export { CALLS }
+import useCatalogPlayer from './useCatalogPlayer'
 
 const PAGE_SIZE = 15
 
-const PLAYER_ICON_SIZES = {
-  playButton: { width: 27, height: 26, icon: 30, pauseIcon: 24 },
-  toggleButton: { width: 34, height: 34, icon: 34 },
-  volumeButton: { width: 24, height: 24, icon: 20 },
-  downloadButton: { width: 24, height: 24, icon: 20 },
-}
-
 export default function CatalogCallList({ activePod }) {
-  const [activeCallId, setActiveCallId] = useState(null)
-  const [isPlaying, setIsPlaying] = useState(false)
-  const [playbackTime, setPlaybackTime] = useState(0)
-  const [isMuted, setIsMuted] = useState(false)
-  const waveSurferRef = useRef(null)
+  const {
+    activeCallId,
+    isPlaying,
+    playbackTime,
+    isMuted,
+    handlePlayPause,
+    handleStop,
+    handleToggleMute,
+    registerWaveSurfer,
+    reportPlaybackStarted,
+    reportPlaybackPaused,
+    reportPlaybackTime,
+    reportPlaybackError,
+  } = useCatalogPlayer()
   const [expandedId, setExpandedId] = useState(null)
   const [page, setPage] = useState(1)
-
-  const handlePlayPause = useCallback(
-    (call) => {
-      if (!call.audio) return
-
-      if (activeCallId === call.id) {
-        if (isPlaying) {
-          waveSurferRef.current?.pause()
-          setIsPlaying(false)
-        } else {
-          setIsPlaying(true)
-          waveSurferRef.current?.play().catch(() => {
-            setIsPlaying(false)
-          })
-        }
-        return
-      }
-
-      waveSurferRef.current?.stop()
-      waveSurferRef.current = null
-      setActiveCallId(call.id)
-      setIsPlaying(true)
-      setPlaybackTime(0)
-    },
-    [activeCallId, isPlaying]
-  )
-
-  const handleStop = useCallback(() => {
-    waveSurferRef.current?.stop()
-    waveSurferRef.current = null
-    setActiveCallId(null)
-    setIsPlaying(false)
-    setPlaybackTime(0)
-  }, [])
-
-  const handleToggleMute = useCallback(() => {
-    setIsMuted((currentMuted) => {
-      const nextMuted = !currentMuted
-      waveSurferRef.current?.setMuted(nextMuted)
-      return nextMuted
-    })
-  }, [])
 
   const handleToggle = useCallback(
     (callId) => {
@@ -100,13 +51,6 @@ export default function CatalogCallList({ activePod }) {
     return filteredCalls.slice(start, start + PAGE_SIZE)
   }, [filteredCalls, page])
 
-  useEffect(() => {
-    return () => {
-      waveSurferRef.current?.stop()
-      waveSurferRef.current = null
-    }
-  }, [])
-
   return (
     <Box>
       <Divider sx={{ borderColor: '#000' }} />
@@ -122,29 +66,13 @@ export default function CatalogCallList({ activePod }) {
           onToggle={() => handleToggle(call.id)}
           onPlayPause={() => handlePlayPause(call)}
           onStop={handleStop}
-          onWaveSurferReady={(waveSurfer) => {
-            if (activeCallId === call.id) {
-              waveSurferRef.current = waveSurfer
-              waveSurfer?.setMuted(isMuted)
-            }
-          }}
-          onPlaybackStarted={() => {
-            if (activeCallId !== call.id) return
-            setIsPlaying(true)
-            pushToDataLayer('audio_play', {
-              call_name: call.id,
-              section: 'call_catalog',
-            })
-          }}
-          onPlaybackPaused={() => {
-            if (activeCallId === call.id) setIsPlaying(false)
-          }}
-          onPlaybackTimeChange={(time) => {
-            if (activeCallId === call.id) setPlaybackTime(time)
-          }}
-          onPlaybackError={() => {
-            if (activeCallId === call.id) handleStop()
-          }}
+          onWaveSurferReady={(waveSurfer) =>
+            registerWaveSurfer(call, waveSurfer)
+          }
+          onPlaybackStarted={() => reportPlaybackStarted(call)}
+          onPlaybackPaused={() => reportPlaybackPaused(call)}
+          onPlaybackTimeChange={(time) => reportPlaybackTime(call, time)}
+          onPlaybackError={() => reportPlaybackError(call)}
           onToggleMute={handleToggleMute}
           downloadPath={call.audio}
         />
@@ -162,393 +90,6 @@ export default function CatalogCallList({ activePod }) {
             shape="rounded"
           />
         </Box>
-      )}
-    </Box>
-  )
-}
-
-function CallRow({
-  call,
-  isActive,
-  isPlaying,
-  expanded,
-  playbackTime,
-  isMuted,
-  onToggle,
-  onPlayPause,
-  onStop,
-  onWaveSurferReady,
-  onPlaybackStarted,
-  onPlaybackPaused,
-  onPlaybackTimeChange,
-  onPlaybackError,
-  onToggleMute,
-  downloadPath,
-}) {
-  const hasAudio = !!call.audio
-  const callLabel = call.label ?? call.id
-  const thumbnailSrc = call.colorSpec
-  const waveformSrc = call.waveform
-  const duration = call.duration ?? 0
-
-  return (
-    <>
-      <Box
-        onClick={onToggle}
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          py: 2,
-          gap: { xs: 1.25, md: 2 },
-          minHeight: '100px',
-          flexWrap: { xs: 'wrap', md: 'nowrap' },
-          pl: { md: '33px' },
-          pr: { md: '31px' },
-          cursor: 'pointer',
-        }}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            alignItems: 'center',
-            flex: { xs: '1 1 100%', md: '0 0 auto' },
-            flexShrink: 0,
-          }}
-        >
-          {/* Spectrogram thumbnail */}
-          <Box
-            sx={{
-              width: 75,
-              height: 75,
-              flexShrink: 0,
-              background: thumbnailSrc ? '#f0f0f0' : 'transparent',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              borderRadius: 1,
-              overflow: 'hidden',
-              border: 'none',
-              boxSizing: 'border-box',
-            }}
-          >
-            {thumbnailSrc ? (
-              <Image
-                src={thumbnailSrc}
-                alt={`Spectrogram for ${callLabel}`}
-                width={75}
-                height={75}
-                style={{
-                  objectFit: 'cover',
-                  maxWidth: '100%',
-                  height: 'auto',
-                }}
-              />
-            ) : null}
-          </Box>
-
-          {/* Play / Pause button */}
-          {hasAudio && (
-            <IconButton
-              onClick={(event) => {
-                event.stopPropagation()
-                onPlayPause()
-              }}
-              aria-label={`${isPlaying ? 'Pause' : 'Play'} ${callLabel}`}
-              sx={{
-                bgcolor: '#fff',
-                borderRadius: '2px',
-                width: PLAYER_ICON_SIZES.playButton.width,
-                height: PLAYER_ICON_SIZES.playButton.height,
-                padding: 0,
-                flexShrink: 0,
-                ml: { xs: 1.25, md: '37px' },
-              }}
-            >
-              {isPlaying ? (
-                <PauseIcon
-                  sx={{
-                    color: '#000',
-                    fontSize: PLAYER_ICON_SIZES.playButton.pauseIcon,
-                  }}
-                />
-              ) : (
-                <PlayArrowIcon
-                  sx={{
-                    color: '#000',
-                    fontSize: PLAYER_ICON_SIZES.playButton.icon,
-                  }}
-                />
-              )}
-            </IconButton>
-          )}
-          {!hasAudio && (
-            <Box
-              aria-hidden="true"
-              sx={{
-                width: PLAYER_ICON_SIZES.playButton.width,
-                height: PLAYER_ICON_SIZES.playButton.height,
-                flexShrink: 0,
-                ml: { xs: 1.25, md: '37px' },
-              }}
-            />
-          )}
-
-          {/* Call ID */}
-          <Box
-            sx={{
-              width: { xs: 'auto', md: 260 },
-              minWidth: { xs: 150, md: 0 },
-              ml: { xs: 1.25, md: '34px' },
-              flexShrink: 0,
-            }}
-          >
-            <Box>
-              <Typography
-                sx={{
-                  fontFamily: 'Montserrat',
-                  fontWeight: 700,
-                  fontSize: '22px',
-                  lineHeight: 1.2,
-                }}
-              >
-                {callLabel}
-              </Typography>
-            </Box>
-          </Box>
-
-          {/* Expand toggle */}
-          <IconButton
-            onClick={(event) => {
-              event.stopPropagation()
-              onToggle()
-            }}
-            aria-label={`${expanded ? 'Collapse' : 'Expand'} ${callLabel}`}
-            sx={{
-              width: PLAYER_ICON_SIZES.toggleButton.width,
-              height: PLAYER_ICON_SIZES.toggleButton.height,
-              p: 0,
-              flexShrink: 0,
-              ml: { xs: 1.25, md: '12px' },
-            }}
-          >
-            <ExpandMoreOutlinedIcon
-              sx={{
-                color: '#000',
-                fontSize: PLAYER_ICON_SIZES.toggleButton.icon,
-                transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
-                transition: 'transform 160ms ease',
-              }}
-            />
-          </IconButton>
-        </Box>
-
-        {hasAudio && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-              flex: { xs: '1 1 100%', md: '0 0 auto' },
-              flexShrink: 0,
-              ml: { md: 'auto' },
-            }}
-          >
-            {/* Timestamp */}
-            <Typography
-              sx={{
-                fontFamily: 'Montserrat',
-                fontWeight: 400,
-                fontSize: { xs: '14px', md: '18px' },
-                lineHeight: 1,
-                width: { xs: 'auto', md: 96 },
-                textAlign: { xs: 'left', md: 'right' },
-                flexShrink: 0,
-              }}
-            >
-              {formatPlaybackTime(playbackTime)}/{formatDuration(duration)}
-            </Typography>
-
-            {/* Waveform strip from the audio file */}
-            <Box
-              sx={{
-                width: { xs: 'min(48vw, 220px)', md: 295 },
-                height: 64,
-                flexShrink: 0,
-                ml: { xs: 1.25, md: '27px' },
-              }}
-            >
-              <Box
-                component={isActive ? WaveformPlayer : StaticWaveform}
-                audioSrc={call.audio}
-                waveformSrc={waveformSrc}
-                isActive={isActive}
-                shouldPlay={isPlaying}
-                isMuted={isMuted}
-                onReady={onWaveSurferReady}
-                onPlaybackStarted={onPlaybackStarted}
-                onPlaybackPaused={onPlaybackPaused}
-                onPlaybackTimeChange={onPlaybackTimeChange}
-                onFinish={onStop}
-                onError={onPlaybackError}
-              />
-            </Box>
-
-            <IconButton
-              onClick={(event) => {
-                event.stopPropagation()
-                onToggleMute()
-              }}
-              aria-label={`${isMuted ? 'Unmute' : 'Mute'} ${callLabel}`}
-              sx={{
-                width: PLAYER_ICON_SIZES.volumeButton.width,
-                height: PLAYER_ICON_SIZES.volumeButton.height,
-                p: 0,
-                flexShrink: 0,
-                ml: { xs: 1.25, md: '33px' },
-              }}
-            >
-              {isMuted ? (
-                <VolumeOffIcon
-                  sx={{
-                    color: '#000',
-                    fontSize: PLAYER_ICON_SIZES.volumeButton.icon,
-                  }}
-                />
-              ) : (
-                <VolumeUpIcon
-                  sx={{
-                    color: '#000',
-                    fontSize: PLAYER_ICON_SIZES.volumeButton.icon,
-                  }}
-                />
-              )}
-            </IconButton>
-
-            {/* Download */}
-            <IconButton
-              component="a"
-              href={downloadPath}
-              download={`${callLabel}.mp3`}
-              aria-label={`Download ${callLabel}`}
-              sx={{
-                width: PLAYER_ICON_SIZES.downloadButton.width,
-                height: PLAYER_ICON_SIZES.downloadButton.height,
-                p: 0,
-                flexShrink: 0,
-                ml: { xs: 1.25, md: '16px' },
-              }}
-              onClick={(event) => {
-                event.stopPropagation()
-                pushToDataLayer('download_click', {
-                  call_name: call.id,
-                  section: 'call_catalog',
-                })
-              }}
-            >
-              <DownloadIcon
-                sx={{
-                  color: '#000',
-                  fontSize: PLAYER_ICON_SIZES.downloadButton.icon,
-                }}
-              />
-            </IconButton>
-          </Box>
-        )}
-      </Box>
-      {expanded && (
-        <Box
-          sx={{
-            width: '100%',
-            mx: 'auto',
-            px: { xs: 2, md: 0 },
-            pl: { md: '145px' },
-            pb: 3,
-          }}
-        >
-          <Box
-            sx={{
-              display: 'flex',
-              gap: { xs: 2, md: '66px' },
-              justifyContent: 'center',
-              alignItems: 'center',
-              flexWrap: 'wrap',
-              width: { xs: '100%', md: 'fit-content' },
-              maxWidth: '100%',
-            }}
-          >
-            <SpectrogramPanel
-              src={call.colorSpec}
-              alt={`Color spectrogram for ${callLabel}`}
-              maxWidth={432}
-            />
-            <SpectrogramPanel
-              src={call.bwSpec}
-              alt={`Ford catalog spectrogram for ${callLabel}`}
-              maxWidth={434}
-            />
-          </Box>
-        </Box>
-      )}
-      <Divider sx={{ borderColor: '#000' }} />
-    </>
-  )
-}
-
-function StaticWaveform({ waveformSrc }) {
-  return (
-    <Box
-      component="img"
-      src={waveformSrc}
-      alt=""
-      aria-hidden="true"
-      sx={{
-        display: 'block',
-        width: '100%',
-        height: '100%',
-        objectFit: 'contain',
-      }}
-    />
-  )
-}
-
-function formatWholeSeconds(totalSeconds) {
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = totalSeconds % 60
-
-  return `${minutes}:${seconds.toString().padStart(2, '0')}`
-}
-
-function formatPlaybackTime(seconds) {
-  if (!Number.isFinite(seconds) || seconds <= 0) return '0:00'
-
-  return formatWholeSeconds(Math.floor(seconds))
-}
-
-function formatDuration(seconds) {
-  if (!Number.isFinite(seconds) || seconds <= 0) return '0:00'
-
-  return formatWholeSeconds(Math.ceil(seconds))
-}
-
-function SpectrogramPanel({ src, alt, maxWidth }) {
-  return (
-    <Box
-      aria-hidden={src ? undefined : 'true'}
-      sx={{
-        width: { xs: '100%', sm: maxWidth },
-        maxWidth,
-        overflow: 'hidden',
-        visibility: src ? 'visible' : 'hidden',
-      }}
-    >
-      {src && (
-        <Box
-          component="img"
-          src={src}
-          alt={alt}
-          sx={{ width: '100%', height: 'auto', display: 'block' }}
-        />
       )}
     </Box>
   )

--- a/src/components/Catalog/PodFilter.jsx
+++ b/src/components/Catalog/PodFilter.jsx
@@ -1,0 +1,44 @@
+import { Box, Button } from '@mui/material'
+
+import { POD_FILTERS } from './constants'
+
+export default function PodFilter({ activePod, onSelect }) {
+  return (
+    <Box
+      role="group"
+      aria-label="Filter calls by pod"
+      sx={{
+        display: 'flex',
+        gap: 8,
+        mb: 5,
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+      }}
+    >
+      {POD_FILTERS.map((filter) => (
+        <Button
+          key={filter}
+          onClick={() => onSelect(filter)}
+          aria-pressed={activePod === filter}
+          sx={{
+            fontFamily: 'Montserrat',
+            fontWeight: 400,
+            fontSize: '20px',
+            textTransform: 'none',
+            padding: '13px 22px',
+            height: '59px',
+            width: '144px',
+            borderRadius: '10px',
+            bgcolor: activePod === filter ? '#0f1a4d' : '#1B2B7B',
+            color: '#FFFFFF',
+            '&:hover': {
+              bgcolor: activePod === filter ? '#0f1a4d' : '#2d3ea3',
+            },
+          }}
+        >
+          {filter}
+        </Button>
+      ))}
+    </Box>
+  )
+}

--- a/src/components/Catalog/SpectrogramPanel.jsx
+++ b/src/components/Catalog/SpectrogramPanel.jsx
@@ -1,0 +1,24 @@
+import { Box } from '@mui/material'
+
+export default function SpectrogramPanel({ src, alt, maxWidth }) {
+  return (
+    <Box
+      aria-hidden={src ? undefined : 'true'}
+      sx={{
+        width: { xs: '100%', sm: maxWidth },
+        maxWidth,
+        overflow: 'hidden',
+        visibility: src ? 'visible' : 'hidden',
+      }}
+    >
+      {src && (
+        <Box
+          component="img"
+          src={src}
+          alt={alt}
+          sx={{ width: '100%', height: 'auto', display: 'block' }}
+        />
+      )}
+    </Box>
+  )
+}

--- a/src/components/Catalog/StaticWaveform.jsx
+++ b/src/components/Catalog/StaticWaveform.jsx
@@ -1,0 +1,18 @@
+import { Box } from '@mui/material'
+
+export default function StaticWaveform({ waveformSrc }) {
+  return (
+    <Box
+      component="img"
+      src={waveformSrc}
+      alt=""
+      aria-hidden="true"
+      sx={{
+        display: 'block',
+        width: '100%',
+        height: '100%',
+        objectFit: 'contain',
+      }}
+    />
+  )
+}

--- a/src/components/Catalog/formatTime.js
+++ b/src/components/Catalog/formatTime.js
@@ -1,0 +1,18 @@
+function formatWholeSeconds(totalSeconds) {
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
+export function formatPlaybackTime(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '0:00'
+
+  return formatWholeSeconds(Math.floor(seconds))
+}
+
+export function formatDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '0:00'
+
+  return formatWholeSeconds(Math.ceil(seconds))
+}

--- a/src/components/Catalog/useCatalogPlayer.js
+++ b/src/components/Catalog/useCatalogPlayer.js
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { pushToDataLayer } from '../../utils/gtm'
+
+export default function useCatalogPlayer() {
+  const [activeCallId, setActiveCallId] = useState(null)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [playbackTime, setPlaybackTime] = useState(0)
+  const [isMuted, setIsMuted] = useState(false)
+  const waveSurferRef = useRef(null)
+
+  const handlePlayPause = useCallback(
+    (call) => {
+      if (!call.audio) return
+
+      if (activeCallId === call.id) {
+        if (isPlaying) {
+          waveSurferRef.current?.pause()
+          setIsPlaying(false)
+        } else {
+          setIsPlaying(true)
+          waveSurferRef.current?.play().catch(() => {
+            setIsPlaying(false)
+          })
+        }
+        return
+      }
+
+      waveSurferRef.current?.stop()
+      waveSurferRef.current = null
+      setActiveCallId(call.id)
+      setIsPlaying(true)
+      setPlaybackTime(0)
+    },
+    [activeCallId, isPlaying]
+  )
+
+  const handleStop = useCallback(() => {
+    waveSurferRef.current?.stop()
+    waveSurferRef.current = null
+    setActiveCallId(null)
+    setIsPlaying(false)
+    setPlaybackTime(0)
+  }, [])
+
+  const handleToggleMute = useCallback(() => {
+    setIsMuted((currentMuted) => {
+      const nextMuted = !currentMuted
+      waveSurferRef.current?.setMuted(nextMuted)
+      return nextMuted
+    })
+  }, [])
+
+  const registerWaveSurfer = (call, waveSurfer) => {
+    if (activeCallId === call.id) {
+      waveSurferRef.current = waveSurfer
+      waveSurfer?.setMuted(isMuted)
+    }
+  }
+
+  const reportPlaybackStarted = (call) => {
+    if (activeCallId !== call.id) return
+    setIsPlaying(true)
+    pushToDataLayer('audio_play', {
+      call_name: call.id,
+      section: 'call_catalog',
+    })
+  }
+
+  const reportPlaybackPaused = (call) => {
+    if (activeCallId === call.id) setIsPlaying(false)
+  }
+
+  const reportPlaybackTime = (call, time) => {
+    if (activeCallId === call.id) setPlaybackTime(time)
+  }
+
+  const reportPlaybackError = (call) => {
+    if (activeCallId === call.id) handleStop()
+  }
+
+  useEffect(() => {
+    return () => {
+      waveSurferRef.current?.stop()
+      waveSurferRef.current = null
+    }
+  }, [])
+
+  return {
+    activeCallId,
+    isPlaying,
+    playbackTime,
+    isMuted,
+    handlePlayPause,
+    handleStop,
+    handleToggleMute,
+    registerWaveSurfer,
+    reportPlaybackStarted,
+    reportPlaybackPaused,
+    reportPlaybackTime,
+    reportPlaybackError,
+  }
+}

--- a/src/pages/catalog.jsx
+++ b/src/pages/catalog.jsx
@@ -1,16 +1,11 @@
-import { Box, Button, Container, Typography } from '@mui/material'
+import { Container, Typography } from '@mui/material'
 import Head from 'next/head'
-import React, { useState } from 'react'
 
 import heroImg from '../../public/images/callcatalog.png'
-import { CALLS } from '../components/Catalog/callsData'
-import CatalogCallList from '../components/Catalog/CatalogCallList'
-import { POD_FILTERS } from '../components/Catalog/constants'
+import CallCatalogSection from '../components/Catalog/CallCatalogSection'
 import TopBanner from '../components/TopBanner'
 
 export default function Catalog() {
-  const [activePod, setActivePod] = useState('All Calls')
-
   return (
     <div>
       <Head>
@@ -26,81 +21,7 @@ export default function Catalog() {
       <div id="catalog" />
 
       <Container maxWidth="lg" sx={{ py: 8 }}>
-        {/* Section title */}
-        <Typography
-          variant="h2"
-          sx={{
-            fontFamily: 'Montserrat',
-            fontWeight: 500,
-            fontSize: { xs: '24px', md: '38px' },
-            textAlign: 'center',
-            mb: 3,
-          }}
-        >
-          Southern Resident Killer Whales Call Catalog
-        </Typography>
-
-        {/* Description */}
-        <Typography
-          sx={{
-            fontFamily: 'Mukta',
-            fontWeight: 400,
-            fontSize: '17px',
-            lineHeight: '28px',
-            maxWidth: '939px',
-            mx: 'auto',
-            mb: 5,
-          }}
-        >
-          Orcasound maintains an online catalog of the SRKW calls (built by Val
-          Veirs and his students at Colorado College, based on the Osborne-Ford
-          tape, March 1981, and the call classification of Ford, 1987). You can
-          browse {CALLS.length} Ford call entries and variants recorded
-          throughout the habitat of J, K, and L pod, with available audio,
-          generated waveform images, color spectrograms, and Ford catalog
-          spectrograms.
-        </Typography>
-
-        {/* Pod filter tabs */}
-        <Box
-          role="group"
-          aria-label="Filter calls by pod"
-          sx={{
-            display: 'flex',
-            gap: 8,
-            mb: 5,
-            flexWrap: 'wrap',
-            justifyContent: 'center',
-          }}
-        >
-          {POD_FILTERS.map((filter) => (
-            <Button
-              key={filter}
-              onClick={() => setActivePod(filter)}
-              aria-pressed={activePod === filter}
-              sx={{
-                fontFamily: 'Montserrat',
-                fontWeight: 400,
-                fontSize: '20px',
-                textTransform: 'none',
-                padding: '13px 22px',
-                height: '59px',
-                width: '144px',
-                borderRadius: '10px',
-                bgcolor: activePod === filter ? '#0f1a4d' : '#1B2B7B',
-                color: '#FFFFFF',
-                '&:hover': {
-                  bgcolor: activePod === filter ? '#0f1a4d' : '#2d3ea3',
-                },
-              }}
-            >
-              {filter}
-            </Button>
-          ))}
-        </Box>
-
-        {/* Call list */}
-        <CatalogCallList key={activePod} activePod={activePod} />
+        <CallCatalogSection />
 
         {/* Image credit */}
         <Typography


### PR DESCRIPTION
## What

Pure **structural** refactor of the Call Catalog feature into single-responsibility modules (#291). **No behavior change** — `/catalog` looks and works exactly as before; code was only relocated and wired with imports/exports.

## Structure

The 567-line `CatalogCallList.jsx` and the inline pod filter in `catalog.jsx` are broken into focused modules:

| File | Responsibility |
|---|---|
| `formatTime.js` | time-formatting helpers (`formatPlaybackTime` / `formatDuration`) |
| `StaticWaveform.jsx` | static waveform image |
| `SpectrogramPanel.jsx` | one spectrogram image slot (expanded panel) |
| `CallRow.jsx` | a call row: collapsed row + expanded panel |
| `useCatalogPlayer.js` | playback state + handlers (custom hook) |
| `PodFilter.jsx` | pod filter tab bar |
| `CallCatalogSection.jsx` | owns `activePod`; title / description / filter / list |
| `CatalogCallList.jsx` | slimmed to orchestration: hook + filter + paginate + render |
| `catalog.jsx` | thin page: `Head` + `TopBanner` + `CallCatalogSection` + image credit |

`WaveformPlayer.jsx`, `constants.js`, `callsData.js` untouched.

## Note (small scope deviation)

Removed the dead `export { CALLS }` re-export from `CatalogCallList.jsx`. The issue asked to preserve it, but that was based on an incorrect assumption — nothing imports `CALLS` from there; `catalog.jsx` imports it from `callsData` directly. Verified across the repo.

## Verification

- `npm run lint` — clean (zero warnings)
- `npm run build` — passes (all pages incl. `/catalog` generated)
- Manually smoke-tested `/catalog`: play / pause, mute, expand / collapse, pod switching (incl. the `key={activePod}` reset of expand/page/playback), pagination, download — all behave identically.

Closes #291
