### PR TITLE
#309 Fix section spacing/alignment regressions on Learn and Get Involved

### DIFF
--- a/src/pages/getinvolved.jsx
+++ b/src/pages/getinvolved.jsx
@@ -450,33 +450,35 @@ const DevelopersContent = () => (
 )
 const SupportContent = () => (
   <>
-    <Typography variant="p" fontSize="20px" paragraph={true} align="justify">
-      Help us and our{' '}
-      <Typography variant="soft" color="#1B2B7B">
-        Orcasound network members
+    <Box sx={{ px: '50px', textAlign: 'center', lineHeight: '28px' }}>
+      <Typography variant="p" fontSize="20px" paragraph={true} align="justify">
+        Help us and our{' '}
+        <Typography variant="soft" color="#1B2B7B">
+          Orcasound network members
+        </Typography>
+        {''} by making charitable contribution to our partners, many of whom are
+        501(c)3 organizations Check out the link below to help strengthen and
+        grow our network, while supporting our on-going conservation, research,
+        and educational efforts.
       </Typography>
-      {''} by making charitable contribution to our partners, many of whom are
-      501(c)3 organizations Check out the link below to help strengthen and grow
-      our network, while supporting our on-going conservation, research, and
-      educational efforts.
-    </Typography>
-    <Typography variant="p" fontSize="20px" paragraph={true} align="justify">
-      You can also directly support the many dedicated volunteers who help
-      Orcasound keep running and improve over time. Take a look at our Hacker
-      hall of fame and our Github repositories and consider sponsoring the work
-      of our most-dedicated contributors.
-    </Typography>
-    <ActionButton
-      link="/donate"
-      text="SUPPORT NOW"
-      onClick={() =>
-        pushToDataLayer('cta_click', {
-          cta_text: 'Donate Now',
-          section: 'donate',
-          page: 'get_involved',
-        })
-      }
-    />
+      <Typography variant="p" fontSize="20px" paragraph={true} align="justify">
+        You can also directly support the many dedicated volunteers who help
+        Orcasound keep running and improve over time. Take a look at our Hacker
+        hall of fame and our Github repositories and consider sponsoring the
+        work of our most-dedicated contributors.
+      </Typography>
+      <ActionButton
+        link="/donate"
+        text="SUPPORT NOW"
+        onClick={() =>
+          pushToDataLayer('cta_click', {
+            cta_text: 'Donate Now',
+            section: 'donate',
+            page: 'get_involved',
+          })
+        }
+      />
+    </Box>
     <Box
       sx={{
         display: 'flex',

--- a/src/pages/learn.jsx
+++ b/src/pages/learn.jsx
@@ -73,7 +73,7 @@ const SalishSeaContent = () => (
       State (USA) and British Columbia (Canada)
     </Typography>
 
-    <Box sx={{ textAlign: 'center', my: 4 }}>
+    <Box sx={{ textAlign: 'center', mt: 4 }}>
       <a
         href="https://orcasound.net/ed/booth/local.html?learn"
         target="_blank"
@@ -345,7 +345,8 @@ export const learn = () => {
             id={section.id}
             component="section"
             sx={{
-              py: 8,
+              my: 8,
+              py: section.fullWidthBg ? 8 : 0,
               bgcolor: section.fullWidthBg || 'transparent',
               color: section.textColor || 'inherit',
             }}


### PR DESCRIPTION
## What

Fixes the two spacing/alignment regressions from the Next-16 section-wrapper / StickyNav refactors (#309). No content, link, or analytics changes.

## 1. `/learn` — excessive gap before "3 Common Calls"

**Cause:** the section loop renders every section with `py: 8` (padding, which does **not** collapse), whereas the pre-refactor layout used `my: 8` margins (which **collapse** between adjacent sections). So the inter-section gap doubled (~64px → ~128px), and the Salish Sea image wrapper's `my: 4` bottom margin stacked on top (~160px total).

**Fix:** switch the section wrapper to `my: 8` (collapsing margin) for inter-section spacing, and keep `py` only on the full-width dark section so it retains its background padding. Also drop the Salish image's stacking bottom margin (`my: 4` → `mt: 4`). The Salish → "3 Common Calls" gap goes ~167px → **~71px**, matching the baseline (~64px) and the rest of the page.

## 2. `/getinvolved` — Support copy spacing + left-aligned CTA

**Cause:** when the Support body moved into `SupportContent` during the StickyNav refactor, it lost the section wrapper styles the old donate section (and the current sibling Volunteer/Developers sections) use. Without a centering wrapper, `ActionButton` sits in a plain block and aligns left.

**Fix:** wrap the Support copy + CTA in `<Box sx={{ px: '50px', textAlign: 'center', lineHeight: '28px' }}>`, matching the sibling sections and the pre-refactor donate section. Restores the horizontal spacing and re-centers the `SUPPORT NOW` CTA. (Paragraphs keep their own `align="justify"`, as before.)

## Verification

- `npm run lint` clean, `npm run build` passes.
- `/learn`: Salish → "3 Common Calls" gap ~167px → ~71px (baseline ~64px); dark call-catalog section keeps its padding; jump-link section ids unchanged.
- `/getinvolved`: `SUPPORT NOW` CTA now horizontally centered (measured leftGap == rightGap).
- Desktop smoke-checked both pages.

Closes #309
