### PR TITLE
Add close button to jump-nav drawer; unify mobile menu text color

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -147,7 +147,7 @@ function Mobile() {
             <Link key={navLink.name} href={navLink.url}>
               <ListItem
                 button
-                sx={{ borderBottom: '1px solid white' }}
+                sx={{ borderBottom: '1px solid white', color: 'white' }}
                 onClick={() =>
                   pushToDataLayer('nav_click', {
                     link_text: navLink.name,

--- a/src/components/StickyNav.jsx
+++ b/src/components/StickyNav.jsx
@@ -1,3 +1,4 @@
+import CloseIcon from '@mui/icons-material/Close'
 import MenuIcon from '@mui/icons-material/Menu'
 import {
   Box,
@@ -65,6 +66,7 @@ const StickyNav = ({ navLinks, onLinkClick, id }) => {
             </Typography>
             <IconButton
               onClick={() => setDrawerOpen(true)}
+              aria-label="Open section navigation"
               sx={{ color: '#1e3a8a' }}
             >
               <MenuIcon />
@@ -73,14 +75,33 @@ const StickyNav = ({ navLinks, onLinkClick, id }) => {
               anchor="right"
               open={drawerOpen}
               onClose={() => setDrawerOpen(false)}
+              // Sit above the site AppBar (zIndex: drawer + 1 in Nav.jsx) so
+              // the drawer header and its close button aren't covered by it.
+              sx={{ zIndex: (theme) => theme.zIndex.drawer + 2 }}
             >
               <Box sx={{ width: 280, p: 3 }} role="presentation">
-                <Typography
-                  variant="h6"
-                  sx={{ mb: 3, fontWeight: 700, color: '#1e3a8a' }}
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    mb: 3,
+                  }}
                 >
-                  Sections
-                </Typography>
+                  <Typography
+                    variant="h6"
+                    sx={{ fontWeight: 700, color: '#1e3a8a' }}
+                  >
+                    Sections
+                  </Typography>
+                  <IconButton
+                    onClick={() => setDrawerOpen(false)}
+                    aria-label="Close section navigation"
+                    sx={{ color: '#1e3a8a', mr: -1 }}
+                  >
+                    <CloseIcon />
+                  </IconButton>
+                </Box>
                 <List component="ul" sx={{ p: 0, m: 0, listStyle: 'none' }}>
                   {navLinks.map((link) => (
                     <ListItem key={link.id} sx={{ mb: 2, p: 0 }}>


### PR DESCRIPTION
## What

This PR bundles three related mobile-nav fixes:

1. **Sticky bar** — the jump-nav ("Sections") drawer header was hidden behind the site AppBar (`zIndex: drawer + 1`). Raise the drawer above the AppBar (`zIndex: drawer + 2`) so its header/bar is visible.
2. **Close button** — the drawer had no explicit close control. Add a close (X) button (plus `aria-label`s on the open/close icon buttons).
3. **Unify color** — the first three mobile menu items (internal links) rendered in the theme's primary navy, because the custom `Link` wraps them in a MUI `Link` (default `color="primary"`), while the external items inherited the white list color. Force white on those items so all menu entries match.

## Why

The mobile menu had mixed colors (navy internal links vs. white external links), and the jump-nav drawer was awkward to dismiss and partly hidden behind the AppBar on mobile.

## Files

- `src/components/StickyNav.jsx` — sticky bar (zIndex) + close button + aria-labels
- `src/components/Nav.jsx` — unify mobile menu text color

## Testing

Verified on a mobile viewport: drawer opens/closes via both the X button and backdrop, the header is no longer covered by the AppBar, and all mobile menu entries render white.