### PR TITLE
Fix responsive image layout regressions (#296)

### DIFF
--- a/src/components/About/AboutCard.jsx
+++ b/src/components/About/AboutCard.jsx
@@ -23,19 +23,21 @@ const AboutCard = ({ item, mobileActive, onClick }) => {
       mx={{ xs: 1, sm: 0 }}
     >
       <Paper square elevation={3}>
-        <Box>
+        <Box
+          sx={{
+            position: 'relative',
+            width: '100%',
+            aspectRatio: '700 / 500',
+          }}
+        >
           <Image
-            width={700}
-            height={500}
+            fill
             alt={item.title}
             src={item.path}
-            sx={{
-              userSelect: 'none',
-            }}
-            sizes="100vw"
+            sizes="(max-width: 600px) 100vw, (max-width: 900px) 50vw, 25vw"
             style={{
-              width: '100%',
-              height: 'auto',
+              objectFit: 'cover',
+              userSelect: 'none',
             }}
           />
         </Box>

--- a/src/pages/getinvolved.jsx
+++ b/src/pages/getinvolved.jsx
@@ -59,6 +59,43 @@ const SECTION_COMPONENTS = {
   donate: () => <SupportContent />,
 }
 
+const VOLUNTEER_IMAGE_SIZES = '(max-width: 600px) 100vw, 33vw'
+
+// Next 12's next/image wrapped each image in a span that the grid could
+// stretch to an equal column height. Next 16 renders a bare <img>, which
+// dropped that behavior (#296). Re-create it: on desktop fill an
+// equal-height grid cell (objectFit: cover); on mobile fall back to the
+// image's natural size.
+const VolunteerImage = ({ alt, src, desktopSx }) => (
+  <>
+    <Box
+      sx={{
+        display: { xs: 'none', sm: 'block' },
+        position: 'relative',
+        width: '100%',
+        overflow: 'hidden',
+        ...desktopSx,
+      }}
+    >
+      <Image
+        alt={alt}
+        src={src}
+        fill
+        sizes={VOLUNTEER_IMAGE_SIZES}
+        style={{ objectFit: 'cover' }}
+      />
+    </Box>
+    <Box sx={{ display: { xs: 'block', sm: 'none' } }}>
+      <Image
+        alt={alt}
+        src={src}
+        sizes="100vw"
+        style={{ display: 'block', maxWidth: '100%', height: 'auto' }}
+      />
+    </Box>
+  </>
+)
+
 const VolunteerContent = () => (
   <>
     <Box
@@ -108,8 +145,9 @@ const VolunteerContent = () => (
     <Box
       sx={(theme) => ({
         display: 'grid',
-        gridTemplateColumns: 'auto auto auto',
+        gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
         gridGap: '20px',
+        alignItems: 'stretch',
         [theme.breakpoints.down('sm')]: {
           gridTemplateColumns: '100%',
         },
@@ -123,46 +161,26 @@ const VolunteerContent = () => (
           gridGap: '20px',
         }}
       >
-        <Image
+        <VolunteerImage
           alt="Val hacking node code."
           src={valhacking}
-          style={{
-            width: '100%',
-            height: 'auto',
-            maxWidth: '100%',
-            height: 'auto',
-          }}
+          desktopSx={{ aspectRatio: '379 / 310' }}
         />
-        <Image
+        <VolunteerImage
           alt="Binaural hydrophone stand."
           src={hydrophonestand}
-          style={{
-            width: '100%',
-            height: 'auto',
-            maxWidth: '100%',
-            height: 'auto',
-          }}
+          desktopSx={{ aspectRatio: '375 / 297' }}
         />
       </Box>
-      <Image
+      <VolunteerImage
         alt="Lon does hydrophone wizardly!"
         src={lonhydrophone}
-        style={{
-          width: '100%',
-          height: 'auto',
-          maxWidth: '100%',
-          height: 'auto',
-        }}
+        desktopSx={{ height: '100%' }}
       />
-      <Image
+      <VolunteerImage
         alt="The live-streaming DIY solution."
         src={livediy}
-        style={{
-          width: '100%',
-          height: 'auto',
-          maxWidth: '100%',
-          height: 'auto',
-        }}
+        desktopSx={{ height: '100%' }}
       />
     </Box>
     <Typography variant="body1">


### PR DESCRIPTION
## What

Follow-up to #296 — restore the **equal-height image layout** that PR #273 broke when it dropped `next/image`'s `layout` prop. This is a regression vs the pre-Next-16 build (deploy-preview-290), not a redesign.

## Root cause

Next 12's `next/image` wrapped each image in a `<span>` that the CSS grid could stretch to an equal column height. Next 16 renders a bare `<img>`, so:
- **About cards** took each source image's natural ratio (1.34–1.76) instead of a fixed 700:500 → ragged heights.
- **Get Involved** portrait columns collapsed to their natural (shorter) height → no longer equal to the landscape column.

## Changes

### `src/components/About/AboutCard.jsx`
- Restore the uniform **700:500** ratio (old `layout="responsive"`) with a 700:500 aspect-ratio container + `fill` + `objectFit: cover`.
- Tighten `sizes` to `(max-width:600px) 100vw, (max-width:900px) 50vw, 25vw` to match the `xs={12} sm={6} md={3}` grid.

### `src/pages/getinvolved.jsx` (Volunteer grid)
- Add a `VolunteerImage` wrapper that re-creates the equal-height behavior: **desktop** fills an equal-height grid cell (`fill` + `objectFit: cover`, grid `repeat(3, minmax(0, 1fr))` + `alignItems: stretch`); **mobile** falls back to the image's natural size (`maxWidth:100%; height:auto`).
- Removed the duplicate `height` keys left by the migration.

## Verification (vs deploy-preview-290)

Measured rendered geometry on the actual builds:
- **About cards:** all 8 cards `258×184` (=700:500), uniform — matches 290.
- **Get Involved @1280:** all three columns `354×590` (equal height) — matches 290. (The migrated build was `590 / 528 / 528` — portraits short.)
- `npm run lint:ci` (zero warnings), `npm run format:check`, `npm run build` all pass.

Closes #296.