### PR TITLE
Fix fixed-size Image regressions (#295)

### DIFF
--- a/src/components/Catalog/CallRow.jsx
+++ b/src/components/Catalog/CallRow.jsx
@@ -93,8 +93,6 @@ export default function CallRow({
                 height={75}
                 style={{
                   objectFit: 'cover',
-                  maxWidth: '100%',
-                  height: 'auto',
                 }}
               />
             ) : null}

--- a/src/components/Donate/DonatePartners.jsx
+++ b/src/components/Donate/DonatePartners.jsx
@@ -98,10 +98,6 @@ const DonatePartners = () => {
                 height={100}
                 src={partner.icon}
                 alt={partner.name}
-                style={{
-                  maxWidth: '100%',
-                  height: 'auto',
-                }}
               />
               <Typography sx={{ fontWeight: 'bold', fontSize: '0.9rem' }}>
                 {partner.name}
@@ -146,10 +142,6 @@ const DonatePartners = () => {
                 height={100}
                 src={partner.icon}
                 alt={partner.name}
-                style={{
-                  maxWidth: '100%',
-                  height: 'auto',
-                }}
               />
             </Box>
             <Box


### PR DESCRIPTION
## What

Follow-up to #295 — the Next 16 image codemod (#273) applied `maxWidth: '100%'` + `height: 'auto'` to **all** images, including fixed-size ones. On a fixed-size image, `height: 'auto'` overrides the explicit `height` prop, so the image no longer renders at its intended dimensions.

## Changes

### `src/components/Catalog/CallRow.jsx` — spectrogram thumbnails
- The 75×75 thumbnail sits in a 75×75 box with a light-grey background. `height: 'auto'` made the image shorter than 75px, exposing the grey background as a top/bottom letterbox ("white border").
- Removed `maxWidth: '100%'` + `height: 'auto'`, kept `objectFit: 'cover'` so the image fills the full 75×75 square.

### `src/components/Donate/DonatePartners.jsx` — partner logos
- Removed the `maxWidth: '100%'` + `height: 'auto'` style from both the mobile and the tablet/laptop card `<Image>`s, restoring the intended fixed **100×100** dimensions (matches the pre-Next-16 baseline, which had no inline style on these). Mobile keeps its existing `& img { 4rem }` sizing.

### `src/components/Nav.jsx` — logo (intentionally not touched)
- The 60×44 logo was already moved off the codemod pattern by **#306** (now `width: 60px`), and the issue notes Nav.jsx overlaps #298 and shouldn't be edited twice. Left as-is.

## Verification

- Catalog thumbnail now measures **75×75** in the rendered DOM (was shrinking before).
- `npm run lint:ci` (zero warnings), `npm run format:check`, `npm run build` all pass.
- ⚠️ Deploy-preview visual smoke check (Catalog / Donate) recommended before merge.

Closes #295.