### PR TITLE
Wire About page content (text + images + projects) to Sanity

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,10 @@ module.exports = {
         protocol: 'https',
         hostname: 'netlify.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'cdn.sanity.io',
+      },
     ],
   },
 }

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -40,6 +40,7 @@ export default function About({ about }) {
   const content = {
     heroTitle: about?.heroTitle || DEFAULTS.heroTitle,
     heroDescription: about?.heroDescription || DEFAULTS.heroDescription,
+    heroImage: about?.heroImageUrl || AboutBanner,
     intro: about?.intro || DEFAULTS.intro,
     projectsHeading: about?.projectsHeading || DEFAULTS.projectsHeading,
     participationHeading:
@@ -51,13 +52,25 @@ export default function About({ about }) {
     ctaHref: about?.ctaHref || DEFAULTS.ctaHref,
   }
 
+  // Projects: use the Sanity list when present, otherwise the existing
+  // db.json. Normalize each entry to { title, path, url } so AboutCard
+  // stays unchanged. A project image falls back to the banner so a
+  // half-filled entry can't break rendering.
+  const projects = about?.projects?.length
+    ? about.projects.map((project) => ({
+        title: project.title,
+        path: project.imageUrl || AboutBanner,
+        url: project.url,
+      }))
+    : Items
+
   return (
     <>
       <Head>
         <title>About us - Orcasound</title>
       </Head>
       <TopBanner
-        bannerImg={AboutBanner}
+        bannerImg={content.heroImage}
         pageTitle={content.heroTitle}
         pageDesc={content.heroDescription}
         scrollToId={`about`}
@@ -87,7 +100,7 @@ export default function About({ about }) {
               justifyContent="center"
               spacing={mobileActive ? 0 : 5}
             >
-              {Items.map((item, index) => {
+              {projects.map((item, index) => {
                 return (
                   <Grid item xs={12} sm={6} md={3} key={index}>
                     {/* There are two conditions

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -9,12 +9,47 @@ import AboutBanner from '../../public/images/about.webp'
 import AboutCard from '../components/About/AboutCard'
 import Items from '../components/About/db.json'
 import TopBanner from '../components/TopBanner'
+import { getClient } from '../sanity/client'
+import { ABOUT_PAGE_QUERY } from '../sanity/queries'
 import { pushToDataLayer } from '../utils/gtm'
 import useIsMobile from '../utils/useIsMobile'
 
-export default function About() {
+// Current hard-coded copy, used as a fallback whenever Sanity has no value
+// for a field (or Sanity is unreachable). This keeps the page rendering its
+// existing content until it's filled in the Studio.
+const DEFAULTS = {
+  heroTitle: 'About',
+  heroDescription: `Orcasound is a software & hardware Web app to listen to whales, save orcas and advance bioacoustics (AI technology).`,
+  intro: `Orcasound is a cooperative effort of many dedicated individuals and great organizations. Here are our recent projects — created by volunteers, stewards, citizen scientists, hackers, and generous funders — all working together for the orcas.`,
+  projectsHeading: 'Our Projects',
+  participationHeading: 'We Welcome Your Participation!',
+  participationParagraphs: [
+    `You can join us anytime as a volunteer to our open-source software & hardware projects.`,
+    `If you'd like to host a hydrophone, do research, or incorporate Orcasound into the educational or outreach efforts of your organization, please reach out!`,
+  ],
+  ctaLabel: 'GET INVOLVED',
+  ctaHref: '/getinvolved',
+}
+
+export default function About({ about }) {
   const mobileActive = useIsMobile()
   const [seeMore, setSeeMore] = useState(!mobileActive)
+
+  // Per-field fallback: use the Sanity value when present, otherwise the
+  // existing hard-coded copy.
+  const content = {
+    heroTitle: about?.heroTitle || DEFAULTS.heroTitle,
+    heroDescription: about?.heroDescription || DEFAULTS.heroDescription,
+    intro: about?.intro || DEFAULTS.intro,
+    projectsHeading: about?.projectsHeading || DEFAULTS.projectsHeading,
+    participationHeading:
+      about?.participationHeading || DEFAULTS.participationHeading,
+    participationParagraphs: about?.participationParagraphs?.length
+      ? about.participationParagraphs
+      : DEFAULTS.participationParagraphs,
+    ctaLabel: about?.ctaLabel || DEFAULTS.ctaLabel,
+    ctaHref: about?.ctaHref || DEFAULTS.ctaHref,
+  }
 
   return (
     <>
@@ -23,18 +58,15 @@ export default function About() {
       </Head>
       <TopBanner
         bannerImg={AboutBanner}
-        pageTitle={`About`}
-        pageDesc={`Orcasound is a software & hardware Web app to listen to whales, save orcas and advance bioacoustics (AI technology).`}
+        pageTitle={content.heroTitle}
+        pageDesc={content.heroDescription}
         scrollToId={`about`}
       />
 
       <Box m={3} id="about">
         <Container>
           <Typography mt={9} align="justify" variant="body1">
-            {`Orcasound is a cooperative effort of many dedicated individuals and
-            great organizations. Here are our recent projects — created by
-            volunteers, stewards, citizen scientists, hackers, and generous
-            funders — all working together for the orcas.`}
+            {content.intro}
           </Typography>
 
           <Typography
@@ -46,7 +78,7 @@ export default function About() {
               fontWeight: '600',
             }}
           >
-            Our Projects
+            {content.projectsHeading}
           </Typography>
 
           <Box>
@@ -58,7 +90,7 @@ export default function About() {
               {Items.map((item, index) => {
                 return (
                   <Grid item xs={12} sm={6} md={3} key={index}>
-                    {/* There are two conditions 
+                    {/* There are two conditions
                     1) for mobile
                       a) showing default only two projects  -> (mobileActive && index < 2)
                       b) if user wants to see more Projects -> (seeMore)
@@ -95,31 +127,22 @@ export default function About() {
                 fontWeight: '600',
               }}
             >
-              We Welcome Your Participation!
+              {content.participationHeading}
             </Typography>
 
             <Box my={3}>
-              <Typography
-                mx={1}
-                mt={3}
-                align="left"
-                variant="body1"
-                gutterBottom
-              >
-                {`You can join us anytime as a volunteer to our open-source
-                software & hardware projects.`}
-              </Typography>
-              <Typography
-                mx={1}
-                mt={3}
-                align="left"
-                variant="body1"
-                gutterBottom
-              >
-                {`If you'd like to host a hydrophone, do research, or incorporate
-                Orcasound into the educational or outreach efforts of your
-                organization, please reach out!`}
-              </Typography>
+              {content.participationParagraphs.map((paragraph, index) => (
+                <Typography
+                  key={index}
+                  mx={1}
+                  mt={3}
+                  align="left"
+                  variant="body1"
+                  gutterBottom
+                >
+                  {paragraph}
+                </Typography>
+              ))}
             </Box>
 
             <Box
@@ -142,16 +165,16 @@ export default function About() {
                     color: 'white',
                   },
                 }}
-                href="/getinvolved"
+                href={content.ctaHref}
                 onClick={() =>
                   pushToDataLayer('cta_click', {
-                    cta_text: 'Get Involved',
+                    cta_text: content.ctaLabel,
                     section: 'body',
                     page: 'about',
                   })
                 }
               >
-                GET INVOLVED
+                {content.ctaLabel}
               </Button>
             </Box>
           </Box>
@@ -178,4 +201,17 @@ function Mobile({ setSeeMore, seeMore }) {
       {seeMore ? 'Show less...' : 'See more...'}
     </Typography>
   )
+}
+
+// Fetch the About content from Sanity at build time (revalidated for ISR).
+// If Sanity is unreachable or unconfigured, fall back to null and the
+// component renders its built-in DEFAULTS.
+export async function getStaticProps() {
+  let about = null
+  try {
+    about = await getClient(false).fetch(ABOUT_PAGE_QUERY)
+  } catch {
+    about = null
+  }
+  return { props: { about }, revalidate: 60 }
 }

--- a/src/sanity/client.ts
+++ b/src/sanity/client.ts
@@ -16,7 +16,9 @@ function baseClient(): SanityClient {
     )
   }
   if (!cached) {
-    cached = createClient({ projectId, dataset, apiVersion, useCdn: true })
+    // useCdn:false — pages fetch via getStaticProps/ISR which already caches,
+    // so skip the CDN layer to avoid stale content after an edit.
+    cached = createClient({ projectId, dataset, apiVersion, useCdn: false })
   }
   return cached
 }

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -17,3 +17,29 @@ export interface SanityPage {
   }
   paragraph?: string
 }
+
+/**
+ * About page (Phase 2). Text fields only for now — projects and images
+ * still come from the existing code/db.json until a follow-up slice.
+ */
+export const ABOUT_PAGE_QUERY = `*[_type == "aboutPage"][0]{
+  heroTitle,
+  heroDescription,
+  intro,
+  projectsHeading,
+  participationHeading,
+  participationParagraphs,
+  ctaLabel,
+  ctaHref
+}`
+
+export interface AboutPageContent {
+  heroTitle?: string
+  heroDescription?: string
+  intro?: string
+  projectsHeading?: string
+  participationHeading?: string
+  participationParagraphs?: string[]
+  ctaLabel?: string
+  ctaHref?: string
+}

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -19,25 +19,41 @@ export interface SanityPage {
 }
 
 /**
- * About page (Phase 2). Text fields only for now — projects and images
- * still come from the existing code/db.json until a follow-up slice.
+ * About page (Phase 2/3). Text + hero image + the Projects list (title,
+ * image, link). Image fields resolve the asset to a plain CDN URL via
+ * `asset->url`; the page falls back to the bundled images / db.json when a
+ * value is missing.
  */
 export const ABOUT_PAGE_QUERY = `*[_type == "aboutPage"][0]{
   heroTitle,
   heroDescription,
+  "heroImageUrl": heroImage.asset->url,
   intro,
   projectsHeading,
+  projects[]{
+    title,
+    "imageUrl": image.asset->url,
+    url
+  },
   participationHeading,
   participationParagraphs,
   ctaLabel,
   ctaHref
 }`
 
+export interface AboutProject {
+  title?: string
+  imageUrl?: string
+  url?: string
+}
+
 export interface AboutPageContent {
   heroTitle?: string
   heroDescription?: string
+  heroImageUrl?: string
   intro?: string
   projectsHeading?: string
+  projects?: AboutProject[]
   participationHeading?: string
   participationParagraphs?: string[]
   ctaLabel?: string

--- a/studio/schemaTypes/aboutPage.ts
+++ b/studio/schemaTypes/aboutPage.ts
@@ -1,0 +1,106 @@
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+/**
+ * About page (Phase 2 — first real-page content model).
+ *
+ * Mirrors the editable content currently hard-coded in
+ * `src/pages/about.jsx` + `src/components/About/db.json`. Layout, styling,
+ * the mobile see-more behaviour, and analytics stay in the React component —
+ * only the editorial content lives here.
+ *
+ * Singleton: there is only ever one About page document.
+ */
+export const aboutPage = defineType({
+  name: 'aboutPage',
+  title: 'About Page',
+  type: 'document',
+  fields: [
+    // —— Hero / top banner ——
+    defineField({
+      name: 'heroTitle',
+      title: 'Hero title',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'heroDescription',
+      title: 'Hero description',
+      type: 'text',
+      rows: 2,
+    }),
+    defineField({
+      name: 'heroImage',
+      title: 'Hero image',
+      type: 'image',
+      options: {hotspot: true},
+    }),
+
+    // —— Intro paragraph ——
+    defineField({
+      name: 'intro',
+      title: 'Intro paragraph',
+      type: 'text',
+      rows: 4,
+    }),
+
+    // —— Projects ——
+    defineField({
+      name: 'projectsHeading',
+      title: 'Projects heading',
+      type: 'string',
+    }),
+    defineField({
+      name: 'projects',
+      title: 'Projects',
+      type: 'array',
+      of: [
+        defineArrayMember({
+          type: 'object',
+          fields: [
+            defineField({
+              name: 'title',
+              title: 'Title',
+              type: 'string',
+              validation: (rule) => rule.required(),
+            }),
+            defineField({
+              name: 'image',
+              title: 'Image',
+              type: 'image',
+              options: {hotspot: true},
+            }),
+            defineField({name: 'url', title: 'Link URL', type: 'url'}),
+          ],
+          preview: {select: {title: 'title', media: 'image'}},
+        }),
+      ],
+    }),
+
+    // —— Participation / call to action ——
+    defineField({
+      name: 'participationHeading',
+      title: 'Participation heading',
+      type: 'string',
+    }),
+    defineField({
+      name: 'participationParagraphs',
+      title: 'Participation paragraphs',
+      type: 'array',
+      of: [defineArrayMember({type: 'text'})],
+    }),
+    defineField({
+      name: 'ctaLabel',
+      title: 'CTA button label',
+      type: 'string',
+    }),
+    defineField({
+      name: 'ctaHref',
+      title: 'CTA button link',
+      type: 'string',
+    }),
+  ],
+  preview: {
+    select: {title: 'heroTitle'},
+    prepare: ({title}) => ({title: title || 'About Page'}),
+  },
+})

--- a/studio/schemaTypes/index.ts
+++ b/studio/schemaTypes/index.ts
@@ -1,3 +1,4 @@
+import {aboutPage} from './aboutPage'
 import {page} from './page'
 
-export const schemaTypes = [page]
+export const schemaTypes = [page, aboutPage]


### PR DESCRIPTION
Part of #342 (Sanity content migration, Epic #341). Builds on the merged Phase 1 (#317 / #332).

## What
Moves the About page's editable content into Sanity, with per-field fallback to the existing hard-coded copy / bundled images / `db.json` so the page never breaks when a field (or the whole dataset) is empty.

- **Model** — `aboutPage` singleton schema (`studio/schemaTypes/aboutPage.ts`): hero title/description/image, intro, projects heading, projects[] (title/image/url), participation heading + paragraphs, CTA label/href.
- **Wire** — `ABOUT_PAGE_QUERY` + types in `src/sanity/queries.ts`; `about.jsx` fetches via `getStaticProps` → `getClient` (`revalidate: 60`) with per-field fallback.
  - **Text** → hero text, intro, headings, paragraphs, CTA.
  - **Hero image + Projects** → resolved to plain CDN URLs via GROQ `asset->url`, rendered through the existing `TopBanner` / `AboutCard` (Sanity projects normalized to `{ title, path, url }`, so AboutCard is unchanged). Falls back to `AboutBanner` / `db.json` when empty.
- `next.config.js` — allow `cdn.sanity.io` in `images.remotePatterns`. No new dependency (uses `asset->url`).

## Verified
- `npm run lint:ci` (zero warnings) + `npm run build` pass; `/about` builds as SSG + ISR (1m).
- Locally: **text renders from Sanity** (confirmed), and the **hero/project image path was tested end-to-end** (uploaded an image in Studio → rendered from `cdn.sanity.io` → removed it → fell back cleanly). Build-safe: with no Sanity data it renders the existing content.

## ⚠️ Remaining before this is fully live (operational, not code) — tracked on #342
- [ ] **Netlify env vars not set yet** — *blocked on Netlify access (waiting on Brendan).* Until the 3 `NEXT_PUBLIC_SANITY_*` (+ optional `SANITY_API_READ_TOKEN`) are set for **all deploy contexts**, the deploy preview / production will render the **fallback copy**, not Sanity content. The build still succeeds (build-safe).
- [ ] Seed the real About copy + images into the Studio `aboutPage` document and Publish.
- [ ] Visually smoke-check the deploy preview once env vars are in place.

Opening as **Part of #342** (not `Closes`) since the above operational steps remain.