### PR TITLE
Add priority to above-the-fold LCP images

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -84,6 +84,7 @@ const Nav = () => {
                     style={{ width: '60px', height: 'auto' }}
                     src={orcasoundlogo}
                     alt="Orcasound"
+                    priority
                   />
                 </Link>
               </Box>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -37,6 +37,7 @@ export const index = () => {
           src={orcas}
           alt="orca background image"
           fill
+          priority
           sizes="100vw"
           style={{
             objectFit: 'cover',


### PR DESCRIPTION
## What

Add the `priority` prop to two above-the-fold images:

- **Homepage hero** (`src/pages/index.jsx`) — the full-bleed orca background (`homepage.png`), which is the page's Largest Contentful Paint element.
- **Nav logo** (`src/components/Nav.jsx`) — `logo-white.svg`, rendered in the header on every page.

## Why

`next/image` lazy-loads by default. For above-the-fold images that's backwards: the browser defers the very image it should fetch first, pushing out the LCP and hurting Core Web Vitals. `priority` makes the image load eagerly and adds a `<link rel="preload">`.

These are the two LCP warnings recorded in the #324 cross-browser test matrix (parent #278). Note the console warnings themselves are development-only (Next strips them from production builds), but the underlying LCP cost is real for production users, so the fix is still worthwhile.

## Scope

Deliberately narrow — only the two confirmed above-the-fold LCP images. Mid-page content images (e.g. the Salish Sea image on Learn, the Volunteer section images on Get Involved) keep default lazy loading. Pages using `TopBanner` already load their hero eagerly.

## Testing

- `npm run lint` / `npm run format` clean (pre-commit hook passed).
- Verified on local dev that `priority` takes effect: the rendered `<head>` now emits a `<link rel="preload" as="image">` for both `homepage.png` and `logo-white.svg` (preload is only added for priority images, never for lazy ones). The dev-only LCP warning fires only for a lazy-loaded LCP image, so with these now preloaded/eager that condition no longer holds.

Relates to #327 / #278.