### PR TITLE
studio: link the About editing guide from the Sanity About Page

### DIFF
--- a/studio/schemaTypes/aboutPage.ts
+++ b/studio/schemaTypes/aboutPage.ts
@@ -20,6 +20,9 @@ export const aboutPage = defineType({
       name: 'heroTitle',
       title: 'Hero title',
       type: 'string',
+      description:
+        '📖 New to editing this page? Read the step-by-step guide: ' +
+        'https://docs.google.com/document/d/1kmvkvkVbKbN5ibfVHAJ4o6dhokfEwGbJW1JS8nnbWJc/edit',
       validation: (rule) => rule.required(),
     }),
     defineField({


### PR DESCRIPTION
Adds the content-editor guide link as a description on the About Page's first field in Sanity Studio, so editors see "📖 Read the step-by-step guide" the moment they open the document.

Pairs with the guide itself (#351).

**Note:** the Studio must be redeployed (`orcahome.sanity.studio`) for editors to see this. Also depends on the linked Google Doc being shared as "Anyone with the link — Viewer."