### PR TITLE
docs: refresh README to current state (Vercel, Sanity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-[![Website](https://img.shields.io/website?url=https%3A%2F%2Forcahome.netlify.app)](https://orcahome.netlify.app/)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/a747055d-dd45-4de4-a666-57578ff6837b/deploy-status)](https://app.netlify.com/sites/orcahome/deploys)
-
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Forcasound.tech)](https://orcasound.tech/)
 [![Zulip](https://img.shields.io/badge/zulip-%23orcahome-blue.svg?logo=zulip)](https://orcasound.zulipchat.com/#narrow/channel/437063-orcahome)
 [![License](https://img.shields.io/github/license/orcasound/orcahome)](https://github.com/orcasound/orcahome/blob/master/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/orcasound/orcahome/blob/master/CONTRIBUTING.md)
 [![CI](https://github.com/orcasound/orcahome/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/orcasound/orcahome/actions/workflows/ci.yml)
 
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app). Developed initially as a Google Summer of Code project in 2021 by [Isabella Macchiavello](https://www.linkedin.com/in/isabella-macchiavello-223338205/), the [code is deployed via Netlify](https://orcahome.netlify.app/).
+This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app). Developed initially as a Google Summer of Code project in 2021 by [Isabella Macchiavello](https://www.linkedin.com/in/isabella-macchiavello-223338205/). It powers **[orcasound.tech](https://orcasound.tech/)** and is **deployed on Vercel** (previously Netlify).
 
 ## Cross-browser testing
 
@@ -24,11 +22,15 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+This is a **Pages Router** app: each route is a file under `src/pages/` (e.g. `src/pages/index.jsx` → `/`, `src/pages/getinvolved.jsx` → `/getinvolved`). Page sections are composed from feature components under `src/components/`. Pages auto-update as you edit.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.tsx`.
+## Content editing (Sanity CMS)
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+Some page content is managed in **Sanity CMS** so non-developers can edit it without code changes (starting with the About page). The Studio is at **[orcahome.sanity.studio](https://orcahome.sanity.studio)**, and a step-by-step editor guide lives at [`docs/editing-about-content.md`](docs/editing-about-content.md). Pages fetch content from Sanity with a per-field fallback to the hard-coded copy, so they still render if a field (or the whole dataset) is empty. The migration is tracked in the Sanity CMS epic.
+
+## Deployment
+
+Deployed on **Vercel**; the production domain **[orcasound.tech](https://orcasound.tech/)** points to the Vercel deployment. (The site was previously hosted on Netlify.) CI runs build, lint, and format checks on every PR to `main`.
 
 ## Learn More
 
@@ -36,14 +38,6 @@ To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
 
 ## Donate page data
 
@@ -60,6 +54,6 @@ For any Donate page change, use the [Donate page change issue template](.github/
 
 The Orcasound support flow (Open Collective plus GitHub Sponsors links shown in the Support modal) currently lives inline at [`src/components/Donate/DonateOrcasound.tsx`](src/components/Donate/DonateOrcasound.tsx) and is tracked for a similar data extraction in a follow-up issue.
 
-# Contributing
+## Contributing
 
-``
+See [CONTRIBUTING.md](CONTRIBUTING.md). PRs are welcome — please run `npm run lint` and `npm run format` before pushing.


### PR DESCRIPTION
Brings the README in line with where the project actually is:

- **Deployment**: Netlify → **Vercel**; the site is **orcasound.tech**. Dropped the Netlify website/deploy-status badges.
- **Removed stale `create-next-app` boilerplate** about API routes — this app has none (Pages Router, no `pages/api`). Fixed the editing path to `src/pages/index.jsx`.
- **Added a "Content editing (Sanity CMS)" section** pointing to the Studio (orcahome.sanity.studio) and the editor guide (`docs/editing-about-content.md`).
- Fixed the empty **Contributing** section.

Docs only — no code changes.