### PR TITLE
Dev dashboard: add Upcoming Meeting block + README New Contributors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,48 +3,105 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/orcasound/orcahome/blob/master/CONTRIBUTING.md)
 [![CI](https://github.com/orcasound/orcahome/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/orcasound/orcahome/actions/workflows/ci.yml)
 
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app). Developed initially as a Google Summer of Code project in 2021 by [Isabella Macchiavello](https://www.linkedin.com/in/isabella-macchiavello-223338205/), the code is deployed via Vercel.
+# Orcahome
+
+Orcahome is the [Orcasound](https://www.orcasound.net/) Product Team's proof-of-concept web app (deployed at [orcasound.tech](https://orcasound.tech)), used to prototype and showcase features for the wider Orcasound ecosystem. It is a [Next.js](https://nextjs.org/) app, developed initially as a Google Summer of Code project in 2021 by [Isabella Macchiavello](https://www.linkedin.com/in/isabella-macchiavello-223338205/), and is deployed via Vercel.
+
+## Quick links
+
+- [Dev dashboard](https://orcasound.github.io/orcahome/dev-status.html) — setup guide, open dev issues, who is on what, and the next team sync
+- [Zulip: #orcahome](https://orcasound.zulipchat.com/#narrow/channel/437063-orcahome) — team chat and where dev work is assigned
+- [Open issues](https://github.com/orcasound/orcahome/issues) — the spec for each piece of work is its GitHub issue
 
 ## New contributors
 
 New here? Start with the [Orcahome dev dashboard](https://orcasound.github.io/orcahome/dev-status.html). It walks you through setup (Zulip, GitHub, running locally), shows the open dev issues and who is on what, and lists the next team sync so you can join and get oriented before picking up an issue. Dev work is assigned by the dev lead on Zulip, not self-claimed, so say hi there first.
 
-## Cross-browser testing
+## Tech stack
 
-This project is tested with BrowserStack. BrowserStack supports Orcasound through its Open Source Program, providing free cross-browser and real-device testing including Safari on macOS and iOS.
+- **Framework:** [Next.js](https://nextjs.org/) 16 (primarily the Pages Router; the App Router is used for the Sanity preview and draft-mode API routes)
+- **UI:** [React](https://react.dev/) 18, [MUI](https://mui.com/) v5, and [Emotion](https://emotion.sh/) for styling
+- **Language:** TypeScript (the codebase mixes `.tsx` and legacy `.jsx` files)
+- **Content:** [Sanity](https://www.sanity.io/) headless CMS via `@sanity/client`, with the Sanity Studio in [`studio/`](studio/)
+- **Audio & visualization:** [wavesurfer.js](https://wavesurfer.xyz/), `react-audio-player`, `use-sound`, and `react-zoom-pan-pinch` (for spectrogram pan/zoom)
+- **Tooling:** ESLint, Prettier, and Husky + lint-staged (pre-commit)
+- **Runtime:** Node 20.9.0 (see [`.node-version`](.node-version))
+- **Hosting & CI:** Vercel for deploys; GitHub Actions ([`ci.yml`](.github/workflows/ci.yml)) runs Build, Format, Lint, and Test on each PR
 
-## Getting Started
+## Project structure
 
-First, run the development server:
-
-```bash
-npm run dev
-# or
-yarn dev
+```
+src/
+  pages/        Pages Router routes (home, about, catalog, donate, etc.)
+  app/          App Router routes (Sanity draft-mode API + preview)
+  components/   React components, grouped by page/feature
+  data/         Static JSON/JS content (e.g. donate partners, HHOF contributors)
+  sanity/       Sanity client, env, and GROQ queries
+  styles/       Global styles
+  utils/        Shared helpers (e.g. the donate A/B experiment config)
+  proxy.ts      Middleware for the /donate A/B experiment bucketing
+studio/         Sanity Studio (schemas + config) for editing CMS content
+docs/           Static status dashboards (dev-status.html, ux-status.html)
+public/         Static assets (audio, images)
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Routes
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+| Route                     | Source                                    | Notes                                                        |
+| ------------------------- | ----------------------------------------- | ------------------------------------------------------------ |
+| `/`                       | `src/pages/index.jsx`                     | Home                                                         |
+| `/about`                  | `src/pages/about.jsx`                     | About page (content editable via Sanity)                     |
+| `/catalog`                | `src/pages/catalog.jsx`                   | Call catalog with spectrograms and audio                     |
+| `/donate`                 | `src/pages/donate.jsx`                    | Donate page (A/B test entry point, bucketed in `proxy.ts`)   |
+| `/donate-v2`              | `src/pages/donate-v2.jsx`                 | Internal A/B variant only; direct hits redirect to `/donate` |
+| `/getinvolved`            | `src/pages/getinvolved.jsx`               | Ways to get involved                                         |
+| `/hacker-hall-of-fame`    | `src/pages/hacker-hall-of-fame.jsx`       | Contributor hall of fame                                     |
+| `/learn`                  | `src/pages/learn.jsx`                     | Learn/education content                                      |
+| `/sanity-preview/[slug]`  | `src/app/sanity-preview/[slug]/page.tsx`  | Draft preview of Sanity content                              |
+| `/api/draft-mode/enable`  | `src/app/api/draft-mode/enable/route.ts`  | Enables Next.js draft mode for Sanity previews               |
+| `/api/draft-mode/disable` | `src/app/api/draft-mode/disable/route.ts` | Disables draft mode                                          |
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.tsx`.
+## Getting started
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+### Prerequisites
 
-## Learn More
+- Node 20.9.0 (see [`.node-version`](.node-version); a version manager like `nvm` or `fnm` will pick this up)
+- npm
 
-To learn more about Next.js, take a look at the following resources:
+### Install and run
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+npm install
+npm run dev
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+Open [http://localhost:3000](http://localhost:3000) to view the site. Pages live in `src/pages` and auto-update as you edit.
 
-## Deploy on Vercel
+### Environment variables
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Sanity-backed content (e.g. the About page and previews) needs environment variables. Copy the example file and fill in the values:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+```bash
+cp .env.example .env.local
+```
+
+`.env.local` is gitignored. The app is designed to build without these set — Sanity is created lazily, and a friendly error only surfaces if a preview route is hit while unconfigured. See [`.env.example`](.env.example) for the full list and where to get a read token.
+
+## Available scripts
+
+| Script                 | Description                              |
+| ---------------------- | ---------------------------------------- |
+| `npm run dev`          | Start the development server             |
+| `npm run build`        | Production build                         |
+| `npm run start`        | Serve the production build               |
+| `npm run lint`         | Run ESLint                               |
+| `npm run lint:fix`     | Run ESLint with autofix                  |
+| `npm run format`       | Format the codebase with Prettier        |
+| `npm run format:check` | Check formatting without writing changes |
+
+## Content management (Sanity)
+
+Editable content is managed in [Sanity](https://www.sanity.io/). The Studio lives in [`studio/`](studio/) (see [`studio/README.md`](studio/README.md) for running it). The web app reads content through the client in [`src/sanity/`](src/sanity/), using Incremental Static Regeneration so published edits appear without a redeploy. Draft mode lets editors preview unpublished content via the `/api/draft-mode/*` routes and `/sanity-preview/[slug]`.
 
 ## Donate page data
 
@@ -61,6 +118,10 @@ For any Donate page change, use the [Donate page change issue template](.github/
 
 The Orcasound support flow (Open Collective plus GitHub Sponsors links shown in the Support modal) currently lives inline at [`src/components/Donate/DonateOrcasound.tsx`](src/components/Donate/DonateOrcasound.tsx) and is tracked for a similar data extraction in a follow-up issue.
 
-# Contributing
+## Cross-browser testing
 
-``
+This project is tested with BrowserStack. BrowserStack supports Orcasound through its Open Source Program, providing free cross-browser and real-device testing including Safari on macOS and iOS.
+
+## Contributing
+
+Contributions are welcome. Dev work is assigned by the dev lead on Zulip rather than self-claimed, so introduce yourself in the [#orcahome Zulip channel](https://orcasound.zulipchat.com/#narrow/channel/437063-orcahome) and check the [dev dashboard](https://orcasound.github.io/orcahome/dev-status.html) for open issues before starting. The spec for each task is its GitHub issue. Please open PRs against `main`; CI will run Build, Format, Lint, and Test.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app). Developed initially as a Google Summer of Code project in 2021 by [Isabella Macchiavello](https://www.linkedin.com/in/isabella-macchiavello-223338205/), the code is deployed via Vercel.
 
+## New contributors
+
+New here? Start with the [Orcahome dev dashboard](https://orcasound.github.io/orcahome/dev-status.html). It walks you through setup (Zulip, GitHub, running locally), shows the open dev issues and who is on what, and lists the next team sync so you can join and get oriented before picking up an issue. Dev work is assigned by the dev lead on Zulip, not self-claimed, so say hi there first.
+
 ## Cross-browser testing
 
 This project is tested with BrowserStack. BrowserStack supports Orcasound through its Open Source Program, providing free cross-browser and real-device testing including Safari on macOS and iOS.

--- a/docs/dev-status.html
+++ b/docs/dev-status.html
@@ -56,12 +56,13 @@ a:hover { text-decoration: underline; }
 .person ul { margin: 0; padding-left: 18px; }
 .person li { margin: 2px 0; }
 #status { font-size: 12px; color: #555; margin: 12px 2px; }
-.meeting { background:#fff; border:1px solid #e2e2e8; border-left:5px solid #2f8f54; border-radius:12px; padding:14px 18px; margin:18px 0 4px; }
-.meeting h2 { border:0; margin:0 0 6px; padding:0; font-size:16px; color:#14532d; }
-.meeting .when { font-size:14px; font-weight:600; }
-.meeting .desc { font-size:12.5px; color:#555; margin:6px 0 10px; }
-.meeting .join { display:inline-block; background:#2f8f54; color:#fff; border-radius:7px; padding:6px 13px; font-size:13px; font-weight:600; }
-.meeting .join:hover { background:#277345; text-decoration:none; }
+.meeting { background: #fff; border: 1px solid #e2e2e8; border-left: 5px solid #2f8f54; border-radius: 12px; padding: 14px 18px; margin: 18px 0 4px; }
+.meeting h2 { border: 0; margin: 0 0 6px; padding: 0; font-size: 16px; color: #14532d; }
+.meeting .when { font-size: 14px; font-weight: 600; }
+.meeting .desc { font-size: 12.5px; color: #555; margin: 6px 0 10px; }
+.meeting .join { display: inline-block; background: #2f8f54; color: #fff; border-radius: 7px; padding: 6px 13px; font-size: 13px; font-weight: 600; }
+.meeting .join:hover { background: #277345; text-decoration: none; }
+.meeting .join:focus-visible { outline: 3px solid #14532d; outline-offset: 2px; }
 </style>
 </head>
 <body>

--- a/docs/dev-status.html
+++ b/docs/dev-status.html
@@ -108,10 +108,10 @@ const AUTO = "BT-Orcasound-Product";
 const UPCOMING_MEETING = {
   show: true,
   title: "Orcahome Sprint 3 Wrap Up",
-  when: "Monday, June 22, 2026, 10:00 to 11:00 AM Pacific",
-  joinUrl: "https://us06web.zoom.us/j/89864233616?pwd=c1HSgJF9c7TOX9frEtflpRt3gMki69.1",
-  joinLabel: "Join the Zoom meeting",
-  note: "New here? Drop into the next team sync to meet everyone and get oriented before taking on an issue. Zoom passcode 440858."
+  when: "Monday, July 27, 2026, 10:00 to 11:00 AM Pacific",
+  joinUrl: "https://orcasound.zulipchat.com/#narrow/channel/437063-orcahome",
+  joinLabel: "Get the Google Meet link on Zulip",
+  note: "New here? Drop into the next team sync to meet everyone and get oriented before taking on an issue. The Google Meet link is posted in the orcahome channel on Zulip."
 };
 function renderMeeting(){
   const el=document.getElementById("meeting");

--- a/docs/dev-status.html
+++ b/docs/dev-status.html
@@ -56,6 +56,12 @@ a:hover { text-decoration: underline; }
 .person ul { margin: 0; padding-left: 18px; }
 .person li { margin: 2px 0; }
 #status { font-size: 12px; color: #555; margin: 12px 2px; }
+.meeting { background:#fff; border:1px solid #e2e2e8; border-left:5px solid #2f8f54; border-radius:12px; padding:14px 18px; margin:18px 0 4px; }
+.meeting h2 { border:0; margin:0 0 6px; padding:0; font-size:16px; color:#14532d; }
+.meeting .when { font-size:14px; font-weight:600; }
+.meeting .desc { font-size:12.5px; color:#555; margin:6px 0 10px; }
+.meeting .join { display:inline-block; background:#2f8f54; color:#fff; border-radius:7px; padding:6px 13px; font-size:13px; font-weight:600; }
+.meeting .join:hover { background:#277345; text-decoration:none; }
 </style>
 </head>
 <body>
@@ -66,6 +72,8 @@ a:hover { text-decoration: underline; }
     <div class="refreshed" id="refreshed"></div>
     <button class="btn" onclick="loadReport()">Refresh now</button>
   </header>
+
+  <div class="meeting" id="meeting"></div>
 
   <div class="onboard">
     <h2>Get set up</h2>
@@ -96,6 +104,26 @@ a:hover { text-decoration: underline; }
 <script>
 const API = "https://api.github.com/repos/orcasound/orcahome/issues";
 const AUTO = "BT-Orcasound-Product";
+
+const UPCOMING_MEETING = {
+  show: true,
+  title: "Orcahome Sprint 3 Wrap Up",
+  when: "Monday, June 22, 2026, 10:00 to 11:00 AM Pacific",
+  joinUrl: "https://us06web.zoom.us/j/89864233616?pwd=c1HSgJF9c7TOX9frEtflpRt3gMki69.1",
+  joinLabel: "Join the Zoom meeting",
+  note: "New here? Drop into the next team sync to meet everyone and get oriented before taking on an issue. Zoom passcode 440858."
+};
+function renderMeeting(){
+  const el=document.getElementById("meeting");
+  if(!el) return;
+  const m=UPCOMING_MEETING;
+  if(!m||!m.show){ el.style.display="none"; return; }
+  let h='<h2>Upcoming meeting</h2>';
+  h+='<div class="when">'+esc(m.title)+' &middot; '+esc(m.when)+'</div>';
+  if(m.note) h+='<div class="desc">'+esc(m.note)+'</div>';
+  if(m.joinUrl) h+='<a class="join" href="'+esc(m.joinUrl)+'" target="_blank" rel="noopener">'+esc(m.joinLabel||"Join the meeting")+'</a>';
+  el.innerHTML=h;
+}
 
 // GitHub handle to display name (Orcahome dev team).
 const NAMES = {
@@ -240,6 +268,7 @@ async function loadReport(){
     document.getElementById("content").innerHTML='<div class="err">Could not load live data from GitHub. '+esc(String(e&&e.message?e.message:e))+'<br><br>This page reads the public GitHub API for orcasound/orcahome. If it keeps failing, the repo may be private or the API may be rate limited; open the issues directly at https://github.com/orcasound/orcahome/issues</div>';
   }
 }
+renderMeeting();
 loadReport();
 </script>
 </body>


### PR DESCRIPTION
## Summary

Two newcomer-experience improvements suggested by Vicky and Benji and approved by Brendan.

Closes #334

## Changes

### 1. Upcoming Meeting block (`docs/dev-status.html`)

Adds a block at the top of the dev dashboard showing the next team sync with a Join button, so a new or curious contributor can drop into the next meeting and get oriented before picking up an issue. It runs off a small `UPCOMING_MEETING` config so the meeting can be updated in seconds each sprint (edit the fields; set `show: false` when nothing is scheduled).

- Added `.meeting` styles alongside the existing CSS
- Added the `<div class="meeting" id="meeting">` container right after the header
- Added the `UPCOMING_MEETING` config and `renderMeeting()` renderer, called on load

### 2. New Contributors link (`README.md`)

Adds a `## New contributors` section near the top pointing newcomers to the dev dashboard for setup, open issues, ownership, and the next team sync.

## Notes

- `docs/dev-status.html` is in `.prettierignore`, so it is not expected to pass the CI Format check.
