### PR TITLE
Nav: fix logo jump on load (SSR/hydration mismatch)

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -21,7 +21,6 @@ import React, { useState } from 'react'
 
 import orcasoundlogo from '../../public/images/logo-white.svg'
 import { pushToDataLayer } from '../utils/gtm'
-import useIsMobile from '../utils/useIsMobile'
 import Link from './Link'
 
 const navLinks = [
@@ -63,8 +62,12 @@ const navLinks = [
 
 const Nav = () => {
   const theme = useTheme()
-  const isMobile = useIsMobile()
 
+  // Mobile vs desktop is switched with CSS breakpoints (not a JS/media-query
+  // hook) so the server and the first client render are identical. A JS switch
+  // renders the mobile nav on the server (media queries can't be evaluated
+  // there) and then swaps to desktop on hydration, which makes the logo visibly
+  // jump. Rendering both and toggling `display` avoids that layout shift.
   return (
     <ThemeProvider theme={theme}>
       <AppBar position="relative" sx={{ zIndex: theme.zIndex.drawer + 1 }}>
@@ -89,13 +92,22 @@ const Nav = () => {
                 </Link>
               </Box>
             </Box>
-            {isMobile ? (
-              <Box sx={{ marginLeft: 'auto' }}>
-                <Mobile />
-              </Box>
-            ) : (
+            {/* Desktop nav (lg and up) */}
+            <Box
+              sx={{
+                display: { xs: 'none', lg: 'flex' },
+                flexGrow: 0.6,
+                alignItems: 'center',
+              }}
+            >
               <Desktop />
-            )}
+            </Box>
+            {/* Mobile nav (below lg) */}
+            <Box
+              sx={{ display: { xs: 'flex', lg: 'none' }, marginLeft: 'auto' }}
+            >
+              <Mobile />
+            </Box>
           </Toolbar>
         </Container>
       </AppBar>


### PR DESCRIPTION
## Problem
On every page load the site logo briefly appears in the wrong place, then jumps to its correct position — in production, not just dev.

## Cause
`Nav` chose mobile vs desktop with `useIsMobile()`, a `useMediaQuery` hook. Media queries **can't be evaluated during SSR**, so the hook returns `mobile` on the server → the server renders the **mobile** nav. On hydration the client re-evaluates, gets **desktop**, and swaps the layout — repositioning the logo. That JSX swap is the visible jump.

## Fix
Render **both** the mobile and desktop navs and toggle them with CSS `display` breakpoints (`{ xs: 'flex', lg: 'none' }` / `{ xs: 'none', lg: 'flex' }`). The server and the first client render are now identical, so there's no hydration layout shift. Removed the now-unused `useIsMobile` import from `Nav`.

## Verified
- SSR HTML now contains the desktop nav links directly (previously only the mobile menu).
- Desktop nav bar renders correctly (logo + links + Notify Me / Support buttons) — confirmed via screenshot.
- `lint` + `build` pass.

Affects the global Nav on every page.