### PR TITLE
Nav: add Support/donate link to mobile hamburger menu

### DIFF
--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -182,9 +182,27 @@ function Mobile() {
           href="https://www.orcasound.net/subscribe/"
           target="_blank"
           rel="noopener noreferrer"
+          sx={{ borderBottom: '1px solid white' }}
         >
           <ListItemText primary="Notify Me" />
         </ListItem>
+        {/* Support/donate — desktop has this as a button; mirror it here so
+            mobile/tablet users can still reach /donate from the menu. */}
+        <Link href="/donate">
+          <ListItem
+            button
+            sx={{ color: 'white' }}
+            onClick={() =>
+              pushToDataLayer('nav_click', {
+                link_text: 'Support',
+                page_location:
+                  typeof window !== 'undefined' ? window.location.pathname : '',
+              })
+            }
+          >
+            <ListItemText primary="Support" />
+          </ListItem>
+        </Link>
       </List>
     </Box>
   )


### PR DESCRIPTION
## Problem

The desktop navigation renders a **Support** button linking to `/donate` (in `Desktop()`), but the mobile hamburger menu (`Mobile()`) only maps over the shared `navLinks` array plus a "Notify Me" item. The donate link is hard-coded only in the desktop branch, so **mobile and tablet users have no way to reach `/donate` from the navigation.**

This was surfaced by the cross-browser test matrix in #360 (noted for Android/iOS/tablet, though it was recorded only in the notes column, not the pass/fail grid).

## Fix

Mirror the Support → `/donate` link in the mobile `Drawer` list, placed after "Notify Me" to match the desktop ordering. It reuses the existing internal-link style (`Link` wrapper) and the `nav_click` analytics event used by the other menu items. Also added a bottom divider to "Notify Me" so item separators stay consistent.

## Testing

- `npm run build` passes; `eslint src/components/Nav.jsx` clean.
- Verified in local dev: at mobile/tablet width the hamburger menu now shows **Support**, which routes to `/donate`.
- Desktop nav unchanged.