### PR TITLE
Learn/Footer: fix broken YouTube channel link, share a constant

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -13,6 +13,7 @@ import linkedinlogo from '../../public/images/linkedin.png'
 import orcasoundlogo from '../../public/images/logo-white.svg'
 import xlogo from '../../public/images/x_invert.png'
 import youtubelogo from '../../public/images/youtube.png'
+import { ORCASOUND_YOUTUBE_URL } from '../constants/links'
 import { pushToDataLayer } from '../utils/gtm'
 import useIsMobile from '../utils/useIsMobile'
 import Link from './Link'
@@ -58,7 +59,7 @@ const iconContainer = (
       <LinkedInIcon fontSize="large" />
     </IconLink>
     <IconLink
-      href="https://www.youtube.com/channel/UC7b3tOVQg8_fzaZBj4NoAEg"
+      href={ORCASOUND_YOUTUBE_URL}
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -180,7 +181,7 @@ const iconLinks = [
   },
   {
     name: 'Youtube',
-    url: 'https://www.youtube.com/channel/UC7b3tOVQg8_fzaZBj4NoAEg',
+    url: ORCASOUND_YOUTUBE_URL,
     icon: youtubelogo,
   },
   {

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -1,0 +1,5 @@
+// Canonical Orcasound external URLs shared across pages/components, so a broken
+// link only needs fixing in one place. The `@OrcasoundHydrophones` handle 404s;
+// the channel-ID URL is the working one (see #343).
+export const ORCASOUND_YOUTUBE_URL =
+  'https://www.youtube.com/channel/UC7b3tOVQg8_fzaZBj4NoAEg'

--- a/src/pages/learn.jsx
+++ b/src/pages/learn.jsx
@@ -17,6 +17,7 @@ import { TOOLTIPS } from '../components/Catalog/constants'
 import CallCatalogGrid from '../components/Learn/CallCatalogGrid'
 import StickyNav from '../components/StickyNav'
 import TopBanner from '../components/TopBanner'
+import { ORCASOUND_YOUTUBE_URL } from '../constants/links'
 import { getClient } from '../sanity/client'
 import { LEARN_PAGE_QUERY } from '../sanity/queries'
 import { pushToDataLayer } from '../utils/gtm'
@@ -288,7 +289,7 @@ const CommonCallsContent = ({ content }) => (
       >
         To learn about different pods, please visit the{' '}
         <a
-          href="https://www.youtube.com/@OrcasoundHydrophones"
+          href={ORCASOUND_YOUTUBE_URL}
           target="_blank"
           rel="noopener noreferrer"
           style={{


### PR DESCRIPTION
## Problem

The Learn page ("3 Common Calls" closing sentence) linked to `https://www.youtube.com/@OrcasoundHydrophones`, which returns a **404** (#343). The correct channel-ID URL was also duplicated as a hard-coded string in two places in the Footer.

## Fix

- Add `src/constants/links.ts` exporting `ORCASOUND_YOUTUBE_URL` (the working channel-ID URL).
- Learn page + Footer (icon link and social array) now reference the shared constant instead of hard-coding the URL, so it only needs maintaining in one place.

## Note on the live fix

The Learn "common calls" closing sentence is editable content served from **Sanity** (`learnPage.commonCallsClosing`), and the broken `@OrcasoundHydrophones` href was stored there — so the user-facing 404 was corrected directly in Sanity (now points to the channel-ID URL). This code change fixes the in-code fallback + Footer and removes the duplicated hard-coded URL, matching the issue's "move to a constants file" ask.

## Testing

- `eslint --fix` + `prettier` clean; `npm run build` passes, `/learn` generates cleanly.
- Verified locally: no remaining `@OrcasoundHydrophones` reference; all YouTube links resolve to the channel URL.

Closes #343