### PR TITLE
Get Involved: align roadmap block + following text to full content width

### DIFF
--- a/src/pages/getinvolved.jsx
+++ b/src/pages/getinvolved.jsx
@@ -320,99 +320,96 @@ const DevelopersContent = ({ content }) => (
       {content.crownJewelText}
     </Typography>
     <TechStackList items={content.techStack} />
-    <Box maxWidth="md" mx="auto">
-      <Box px={{ xs: '50px', md: '20px' }}>
-        <Typography
-          variant="p"
-          fontSize="30px"
-          align="justify"
-          paragraph={true}
-          my="40px"
-          textAlign="center"
-          lineHeight="30px"
-        >
-          {content.roadmapHeading}
-        </Typography>
-        <TransformWrapper initialScale={1}>
-          {({ zoomIn, zoomOut, resetTransform }) => (
-            <>
-              <Box
-                sx={{
-                  my: '20px',
-                  textAlign: 'center',
+    <Box>
+      <Typography
+        variant="p"
+        fontSize="30px"
+        align="justify"
+        paragraph={true}
+        my="40px"
+        textAlign="center"
+        lineHeight="30px"
+      >
+        {content.roadmapHeading}
+      </Typography>
+      <TransformWrapper initialScale={1}>
+        {({ zoomIn, zoomOut, resetTransform }) => (
+          <>
+            <Box
+              sx={{
+                my: '20px',
+                textAlign: 'center',
+              }}
+            >
+              <Button
+                variant="outlined"
+                startIcon={<AddIcon />}
+                sx={{ m: 1 }}
+                onClick={() => {
+                  zoomIn()
+                  pushToDataLayer('roadmap_interaction', {
+                    action: 'zoom_in',
+                  })
                 }}
               >
-                <Button
-                  variant="outlined"
-                  startIcon={<AddIcon />}
-                  sx={{ m: 1 }}
-                  onClick={() => {
-                    zoomIn()
-                    pushToDataLayer('roadmap_interaction', {
-                      action: 'zoom_in',
-                    })
-                  }}
-                >
-                  Zoom in
-                </Button>
-                <Button
-                  variant="outlined"
-                  startIcon={<RemoveIcon />}
-                  sx={{ m: 1 }}
-                  onClick={() => {
-                    zoomOut()
-                    pushToDataLayer('roadmap_interaction', {
-                      action: 'zoom_out',
-                    })
-                  }}
-                >
-                  {' '}
-                  Zoom out
-                </Button>
-                <Button
-                  variant="outlined"
-                  sx={{ m: 1 }}
-                  startIcon={<RestartAltIcon />}
-                  onClick={() => {
-                    resetTransform()
-                    pushToDataLayer('roadmap_interaction', {
-                      action: 'reset',
-                    })
-                  }}
-                >
-                  Reset
-                </Button>
-              </Box>
-              <TransformComponent>
-                <Image
-                  {...content.roadmap}
-                  alt="roadmap"
-                  style={{
-                    maxWidth: '100%',
-                    height: 'auto',
-                  }}
-                />
-              </TransformComponent>
-            </>
-          )}
-        </TransformWrapper>
-        <Typography
-          variant="p"
-          fontSize="16px"
-          align="justify"
-          paragraph={true}
-          mt="40px"
-          lineHeight="19.5px"
-        >
-          {content.roadmapCaption}
-        </Typography>
-      </Box>
+                Zoom in
+              </Button>
+              <Button
+                variant="outlined"
+                startIcon={<RemoveIcon />}
+                sx={{ m: 1 }}
+                onClick={() => {
+                  zoomOut()
+                  pushToDataLayer('roadmap_interaction', {
+                    action: 'zoom_out',
+                  })
+                }}
+              >
+                {' '}
+                Zoom out
+              </Button>
+              <Button
+                variant="outlined"
+                sx={{ m: 1 }}
+                startIcon={<RestartAltIcon />}
+                onClick={() => {
+                  resetTransform()
+                  pushToDataLayer('roadmap_interaction', {
+                    action: 'reset',
+                  })
+                }}
+              >
+                Reset
+              </Button>
+            </Box>
+            <TransformComponent>
+              <Image
+                {...content.roadmap}
+                alt="roadmap"
+                style={{
+                  maxWidth: '100%',
+                  height: 'auto',
+                }}
+              />
+            </TransformComponent>
+          </>
+        )}
+      </TransformWrapper>
     </Box>
+    <Typography
+      variant="p"
+      fontSize="16px"
+      align="justify"
+      paragraph={true}
+      mt="40px"
+      lineHeight="19.5px"
+    >
+      {content.roadmapCaption}
+    </Typography>
 
     <Box
       sx={{
         my: '70px',
-        px: '50px',
         textAlign: 'center',
         lineHeight: '28px',
       }}
@@ -492,7 +489,6 @@ const DevelopersContent = ({ content }) => (
     <Box
       sx={{
         my: '150px',
-        px: '50px',
         lineHeight: '28px',
       }}
     >
@@ -689,7 +685,7 @@ const SanityPartners = ({ partners }) => (
 
 const SupportContent = ({ content }) => (
   <>
-    <Box sx={{ px: '50px', textAlign: 'center', lineHeight: '28px' }}>
+    <Box sx={{ textAlign: 'center', lineHeight: '28px' }}>
       {content.supportParagraphs ? (
         content.supportParagraphs.map((paragraph, index) => (
           <Typography


### PR DESCRIPTION
## Problem

In the **Get Involved → Developers** section, several blocks of body copy were rendered at inconsistent widths, so they looked noticeably narrower than the rest of the section:

- The **Current Roadmap** heading, the roadmap diagram, and its caption were wrapped in a `maxWidth="md"` (~900px) centered box — clearly narrower than the tech-stack content above it, which uses the page's `Container maxWidth="lg"` (~1150px).
- The **DemocracyLab** paragraph, the **Memorandum of Agreement** section, and the **Support** intro paragraphs each carried an extra `px: '50px'`, making them ~100px narrower than the surrounding copy.

The result: everything below the roadmap looked squeezed in relative to the content above it.

## Fix

- Remove the `maxWidth="md"` cap (and its inner padding) from the roadmap block so the heading, diagram, and caption span the full container width.
- Remove the stray `px: '50px'` from the DemocracyLab, MOA, and Support text boxes.

All of the section's text now lines up at the `lg` container width. This is a pure layout change to shared markup, so it applies to both the Sanity-driven content and the hard-coded fallback copy.

## Verification

Ran locally against the dev server and captured the Developers section before/after; the roadmap diagram, caption, and the paragraphs below it now align with the tech-stack content above. `npm run lint` and `prettier` clean on the changed file.