### PR TITLE
UX Dashboard: add briefs for #386 and #387 to the BRIEFS map

### DIFF
--- a/docs/ux-status.html
+++ b/docs/ux-status.html
@@ -150,7 +150,9 @@ const BRIEFS = {
   288: "https://drive.google.com/file/d/142uMDR9971LIEdn3gL8YNPVjMSyn15bx/view",
   311: "https://docs.google.com/document/d/1FN6YT2iPUJTqYvZ3nc3IcS1kJr9cU3WHqhaPebaE0dY/edit",
   312: "https://docs.google.com/document/d/1klH7gRgLosTDaf-rdSIAN4NQTOdNsclH-y4Sj1gjKlI/edit",
-  347: "https://drive.google.com/file/d/17zQui-SW-OjtEHqWurbGm4EDVl4tG7Mv/view"
+  347: "https://drive.google.com/file/d/17zQui-SW-OjtEHqWurbGm4EDVl4tG7Mv/view",
+  386: "https://drive.google.com/file/d/1km7YtdWZixlfV3zJ2QwCmr-CVQ29ERrT/view",
+  387: "https://drive.google.com/file/d/1vTbSmzsGPHW4xTNwNLjuaYo9i-9K8F2t/view"
 };
 
 // Design system issues owned by the Lead UX Designer: listed inline with full metadata, but not open to claim.


### PR DESCRIPTION
Adds the design-brief links for issues [#386](https://github.com/orcasound/orcahome/issues/386) (Support page V2 responsive) and [#387](https://github.com/orcasound/orcahome/issues/387) (first-time-visitor research-panel invite) to the `BRIEFS` map in `docs/ux-status.html`, so both show a "Read brief" link and become requestable on the UX Dashboard.

This is the only change: two lines added to the `BRIEFS` object. Per the standing rule that every UX issue has a corresponding design brief and a UX Dashboard listing.