### PR TITLE
UX Dashboard: add briefs for #358 and #385 to the BRIEFS map

### DIFF
--- a/docs/ux-status.html
+++ b/docs/ux-status.html
@@ -151,6 +151,8 @@ const BRIEFS = {
   311: "https://docs.google.com/document/d/1FN6YT2iPUJTqYvZ3nc3IcS1kJr9cU3WHqhaPebaE0dY/edit",
   312: "https://docs.google.com/document/d/1klH7gRgLosTDaf-rdSIAN4NQTOdNsclH-y4Sj1gjKlI/edit",
   347: "https://drive.google.com/file/d/17zQui-SW-OjtEHqWurbGm4EDVl4tG7Mv/view",
+  358: "https://drive.google.com/file/d/1ofAt0fijsclXdC85rDWKvETbuKbX6GxZ/view",
+  385: "https://drive.google.com/file/d/17t1sVFP6G90rPGEcjEHkpm_hvASANauv/view",
   386: "https://drive.google.com/file/d/1km7YtdWZixlfV3zJ2QwCmr-CVQ29ERrT/view",
   387: "https://drive.google.com/file/d/1vTbSmzsGPHW4xTNwNLjuaYo9i-9K8F2t/view"
 };


### PR DESCRIPTION
Adds design-brief links for [#358](https://github.com/orcasound/orcahome/issues/358) (site feedback path) and [#385](https://github.com/orcasound/orcahome/issues/385) (Support page donation copy) to the `BRIEFS` map in `docs/ux-status.html`, so both show a "Read brief" link and become requestable on the UX Dashboard.

Completes the coverage audit: every open UX-titled issue now has a brief and a dashboard listing. Only change is two lines added to the `BRIEFS` object.