### PR TITLE
Get Involved: re-center the Current Roadmap image

### DIFF
--- a/src/pages/getinvolved.jsx
+++ b/src/pages/getinvolved.jsx
@@ -393,7 +393,7 @@ const DevelopersContent = ({ content }) => (
                 Reset
               </Button>
             </Box>
-            <TransformComponent>
+            <TransformComponent wrapperStyle={{ margin: '0 auto' }}>
               <Image
                 {...content.roadmap}
                 alt="roadmap"


### PR DESCRIPTION
The **Current Roadmap** image on `/getinvolved` renders off-center — sitting to the left while the "Current Roadmap" heading and the Zoom in / out / Reset controls above it stay centered.

## Cause
The roadmap image is wrapped in react-zoom-pan-pinch's `<TransformComponent>`, whose wrapper defaults to `width: fit-content`, so it left-aligns within its parent block. #382 ("align roadmap block + following text to full content width") removed the effective centering and exposed this — the heading and control buttons use `textAlign: center` so they were unaffected, which is why only the image looked misplaced.

## Fix
Center the transform wrapper with `wrapperStyle={{ margin: '0 auto' }}` (a `fit-content` block with auto side margins centers horizontally). One-line change; no change to zoom/pan behavior.

## Verify
- `/getinvolved` → the Current Roadmap image is centered under its heading and controls, on desktop and mobile.
- Zoom in / out / reset still work.

Fixes the roadmap-centering regression introduced by #382.
