### PR TITLE
Fix mobile hero overlap, catalog grid, and partner cards

### DIFF
--- a/src/components/Donate/DonatePartners.jsx
+++ b/src/components/Donate/DonatePartners.jsx
@@ -97,14 +97,15 @@ const DonatePartners = ({ title, description, partners: sanityPartners }) => {
             <Box
               sx={{
                 display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'flex-start',
+                flexDirection: 'column',
+                justifyContent: 'center',
                 alignItems: 'center',
                 width: '100%',
                 '& img': {
                   width: '4rem',
                   height: '4rem',
-                  marginRight: '1rem',
+                  marginRight: '0',
+                  marginBottom: '0.5rem',
                 },
               }}
             >

--- a/src/components/Learn/CallCatalogGrid.jsx
+++ b/src/components/Learn/CallCatalogGrid.jsx
@@ -119,7 +119,7 @@ const CallCatalogGrid = () => {
         <Grid
           container
           spacing={{ xs: 2, md: 8 }}
-          columns={{ xs: 4, sm: 8, md: 12 }}
+          columns={12}
           px={{ xs: '5px', md: '30px' }}
         >
           {playArray.map((play, index) => (

--- a/src/components/TopBanner.jsx
+++ b/src/components/TopBanner.jsx
@@ -30,6 +30,12 @@ const TitleScreen = styled(Box)(({ theme }) => ({
     maxHeight: '68vh',
     paddingBottom: '200px',
   },
+  '@media (max-height: 500px)': {
+    minHeight: '100%',
+    maxHeight: '100%',
+    justifyContent: 'center',
+    paddingBottom: '0',
+  },
 }))
 
 const ScrollDownButton = styled(IconButton)(({ theme }) => ({
@@ -65,6 +71,14 @@ const PageDesc = styled(Box)(({ theme }) => ({
     margin: '0',
     width: '100%',
     maxWidth: '100vw',
+  },
+  '@media (max-height: 500px)': {
+    position: 'relative',
+    bottom: 'auto',
+    left: 'auto',
+    margin: '20px auto 0',
+    width: '80%',
+    maxWidth: '450px',
   },
 }))
 


### PR DESCRIPTION

Page : /getinvolved
•	Changes to /getinvolved was made so the “heroDescription” did not cover the page title when in mobile landscape
•	To do this the TopBanner from the component was changed
const PageDesc = styled(Box)(({ theme }) => ({
  position: 'absolute',
  bottom: '0',
  left: '10px',
  backgroundColor: '#080d26',
  width: '40vw',
  maxWidth: '450px',
  margin: '10px 25px',
  padding: '20px',
  letterSpacing: '0.75px',
  [theme.breakpoints.down('sm')]: {
    left: '0',
    margin: '0',
    width: '100%',
    maxWidth: '100vw',
  },
  '@media (max-height: 500px)': {
    position: 'relative',
    bottom: 'auto',
    left: 'auto',
    margin: '20px auto 0',
    width: '80%',
    maxWidth: '450px',
  },
}))

•	The issue is that PageDesc is position: 'absolute' at the bottom, while TitleScreen vertically centers the title. In landscape, the banner is short, so the description box rises into the title.
•	The mobile/short-height layout is changed that the description participates in normal flow instead of being absolutely positioned.
•	Then the description is fixed, but the title is being pushed too high because TitleScreen still has this in landscape: paddingBottom: '100px',

const TitleScreen = styled(Box)(({ theme }) => ({
  position: 'relative',
  minHeight: '85vh',
  maxHeight: '85vh',
  display: 'flex',
  flexDirection: 'column',
  alignItems: 'center',
  justifyContent: 'center',
  color: '#fff',
  paddingBottom: '100px',

  [theme.breakpoints.down('sm')]: {
    minHeight: '68vh',
    maxHeight: '68vh',
    paddingBottom: '200px',
  },

  '@media (max-height: 500px)': {
    minHeight: '100%',
    maxHeight: '100%',
    justifyContent: 'center',
    paddingBottom: '0',
  },
}))
Page: /learn - Southern Resident Killer Whale Call Catalog grid incorrect on mobile landscape
Problem:
The spectrogram cards in the Southern Resident Killer Whale Call Catalog did not align correctly on mobile.
Cause:
The grid defined:
columns={{ xs: 4, sm: 8, md: 12 }}
while each grid item used:
xs={12}
sm={6}
md={4}
At the xs breakpoint, the item was requesting 12 columns from a grid containing only 4.
Fix:
Changed the grid to use a consistent 12-column system:
<Grid
  container
  spacing={{ xs: 2, md: 8 }}
  columns={12}
  px={{ xs: '5px', md: '30px' }}
>
The existing card sizing can then remain:
xs={12}
sm={6}
md={4}
Result:
•	Mobile: 1 card per row 
•	Tablet: 2 cards per row 
•	Desktop: 3 cards per row 
The catalog now responds consistently across screen sizes.


Page : /donate - Donate partner cards were cramped on mobile
Problem:
On the Donate page, partner logos and organization names were displayed side-by-side on narrow screens.
This caused long names such as:
Orca Behavior Institute
Orca Conservancy
Orca Network
to become squeezed beside the logo.
Cause:
The mobile card header used:
flexDirection: 'row',
justifyContent: 'flex-start',
Fix:
Changed the mobile layout to stack and center the logo and organization name:
display: 'flex',
flexDirection: 'column',
justifyContent: 'center',
alignItems: 'center',
width: '100%',
Also changed image spacing from:
marginRight: '1rem',
to:
marginRight: '0',
marginBottom: '0.5rem',
Result:
Mobile partner cards now follow a clearer structure:
Logo

Organization Name

Description

Learn more >>




Partially addresses #275.
