### PR TITLE
Update meeting time and link for Sept 1, 2026

### DIFF
--- a/docs/dev-status.html
+++ b/docs/dev-status.html
@@ -109,10 +109,10 @@ const AUTO = "BT-Orcasound-Product";
 const UPCOMING_MEETING = {
   show: true,
   title: "Orcahome Sprint 3 Wrap Up",
-  when: "Monday, July 27, 2026, 10:00 to 11:00 AM Pacific",
-  joinUrl: "https://orcasound.zulipchat.com/#narrow/channel/437063-orcahome",
-  joinLabel: "Get the Google Meet link on Zulip",
-  note: "New here? Drop into the next team sync to meet everyone and get oriented before taking on an issue. The Google Meet link is posted in the orcahome channel on Zulip."
+  when: "Tuesday, September 1, 2026, 10:00 to 11:00 AM Pacific",
+  joinUrl: "https://orcasound.zulipchat.com/#narrow/channel/437063-orcahome/topic/Orcahome.20Team/with/616663628",
+  joinLabel: "Get the Zoom link on Zulip",
+  note: "New here? Drop into the next team sync to meet everyone and get oriented before taking on an issue. The Zoom link is posted in the orcahome channel on Zulip."
 };
 function renderMeeting(){
   const el=document.getElementById("meeting");


### PR DESCRIPTION
Updates the dev-status page meeting info:

- Date changed to **Tuesday, September 1, 2026**
- Meeting link updated to the specific Zulip topic thread
- "Google Meet" references changed to "Zoom"
