### PR TITLE
Add Sanity-backed blog: schema, /blog landing, and /blog/[slug] posts

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@next/eslint-plugin-next": "^16.2.6",
+        "@sanity/block-tools": "^3.70.0",
+        "@sanity/schema": "^6.10.0",
         "@types/node": "^20.10.0",
         "@types/react": "^18.3.3",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
@@ -40,10 +42,62 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-simple-import-sort": "^13.0.0",
         "husky": "^7.0.4",
+        "jsdom": "^29.1.1",
         "lint-staged": "^12.3.2",
         "prettier": "2.5.1",
         "typescript": "^5.3.3"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -289,6 +343,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -658,6 +865,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -1685,31 +1910,135 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
     },
-    "node_modules/@sanity/client": {
-      "version": "7.22.1",
-      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.22.1.tgz",
-      "integrity": "sha512-DrQqLAes7W9Ek2iKgTZ+ffY1v3DURJ6//iXJZMEQSUeRbxls2ifRTdV1gRS26v8nMkL0OCH+WCoUUseD4vhuQQ==",
+    "node_modules/@sanity/block-tools": {
+      "version": "3.70.0",
+      "resolved": "https://registry.npmjs.org/@sanity/block-tools/-/block-tools-3.70.0.tgz",
+      "integrity": "sha512-2IBAVI3fERu4LTbhDRoH3/FUpZwkAfNh55fi83BF4y0UdtzfniuxIyI9DNrDdf9wHf7rVjpEtFGsHQGXb31UFQ==",
+      "deprecated": "Renamed - use `@portabletext/block-tools` instead. `@sanity/block-tools` will no longer receive updates.",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sanity/eventsource": "^5.0.2",
-        "get-it": "^8.7.2",
-        "nanoid": "^3.3.11",
-        "rxjs": "^7.0.0"
+        "@sanity/types": "3.70.0",
+        "get-random-values-esm": "1.0.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@types/react": "18 || 19"
+      }
+    },
+    "node_modules/@sanity/client": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.26.2.tgz",
+      "integrity": "sha512-iEkGiHbrxCnT/A30A6pH+vX4otP3lLp935Vwuv0/YrnETxrKCn6PnsZU+TfTm6ZEZ9kZGs8wKP5yBLmZw5S6OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.4",
+        "get-it": "^8.8.3",
+        "nanoid": "^3.3.17",
+        "rxjs": "^7.8.2"
       },
       "engines": {
         "node": ">=20"
       }
     },
+    "node_modules/@sanity/descriptors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sanity/descriptors/-/descriptors-1.3.0.tgz",
+      "integrity": "sha512-S2KYYGRUVZy+FDjPp3meoyczbCjobSQvZcgNayo3oYlYS9Qz0E+6RezGxi/KOb6iF52Oir3LEXp9SVfIgEwNjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sha256-uint8array": "^0.10.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@sanity/eventsource": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.2.tgz",
-      "integrity": "sha512-/B9PMkUvAlUrpRq0y+NzXgRv5lYCLxZNsBJD2WXVnqZYOfByL9oQBV7KiTaARuObp5hcQYuPfOAVjgXe3hrixA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-5.0.4.tgz",
+      "integrity": "sha512-NT6XrTJePJd7q1ZdTqB3NsTyNNOe9R2zMkg4Hlkqwb0LL6UmekVamAD46yjSJ+HbRyXAKLl1Rb65xZBdzC1f8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/event-source-polyfill": "1.0.5",
         "@types/eventsource": "1.1.15",
         "event-source-polyfill": "1.0.31",
         "eventsource": "2.0.2"
+      }
+    },
+    "node_modules/@sanity/generate-help-url": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-4.0.0.tgz",
+      "integrity": "sha512-Ooa4xkLT3TLaX+mw/13fq3IeGdnAkx4rbpVASvRVixzBBvvcL6jPqj50fjlCd+EhgB5GRXBCNNAy/hWXwjZEUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sanity/media-library-types": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sanity/media-library-types/-/media-library-types-1.6.0.tgz",
+      "integrity": "sha512-1Nqw8GSUr7E8AFue9luyTOM4Ev0ZlJ35SHcQrHZ6T68G5llfXw99e3GkLXzk6qYFk9r9fJaBTSpW5IyO2mObZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sanity/schema": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sanity/schema/-/schema-6.10.0.tgz",
+      "integrity": "sha512-TnSx7Xvo0wGIVmj6yj54O7pysbcqjXSbqN2XNsPRItalC7W9wztcm7097Nrw8IabRdSOIY03Ofmv6oiuCvsV9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/descriptors": "^1.3.0",
+        "@sanity/generate-help-url": "^4.0.0",
+        "@sanity/types": "6.10.0",
+        "arrify": "^3.0.0",
+        "get-it": "^8.8.3",
+        "groq-js": "^2.0.0",
+        "humanize-list": "^1.0.1",
+        "leven": "^4.1.0",
+        "lodash-es": "^4.18.1",
+        "object-inspect": "^1.13.4"
+      }
+    },
+    "node_modules/@sanity/schema/node_modules/@sanity/types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-6.10.0.tgz",
+      "integrity": "sha512-HywLT2TT6gVrU+6sCocoVh6WNgujFKiiRVM28Mg9B9zz3ZtbHrL6qsOOsZucXw5gXMEt+LFLG5hyhH0j6s7Obw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/client": "^7.26.2",
+        "@sanity/media-library-types": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@sanity/types": {
+      "version": "3.70.0",
+      "resolved": "https://registry.npmjs.org/@sanity/types/-/types-3.70.0.tgz",
+      "integrity": "sha512-Qr2tk9Kr6VP2nL30w/wo+92NI/De+RmpMgkL9jY1hLLWYiGG1c3cJyR2pUK7iIwF3pUHwHPGV+S1APhw5XQ8zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/client": "^6.24.3"
+      },
+      "peerDependencies": {
+        "@types/react": "18 || 19"
+      }
+    },
+    "node_modules/@sanity/types/node_modules/@sanity/client": {
+      "version": "6.29.1",
+      "resolved": "https://registry.npmjs.org/@sanity/client/-/client-6.29.1.tgz",
+      "integrity": "sha512-BQRCMeDlBxwnMbFtB61HUxFf9aSb4HNVrpfrC7IFVqFf4cwcc3o5H8/nlrL9U3cDFedbe4W0AXt1mQzwbY/ljw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/eventsource": "^5.0.2",
+        "get-it": "^8.6.7",
+        "rxjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@swc/helpers": {
@@ -2568,6 +2897,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/arrify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
+      "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2662,6 +3004,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2962,6 +3314,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2972,6 +3338,58 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3039,6 +3457,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "7.0.0",
@@ -3133,6 +3558,12 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3198,6 +3629,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -4288,9 +4732,9 @@
       }
     },
     "node_modules/get-it": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.8.0.tgz",
-      "integrity": "sha512-vRyooMBzoIdEbARGT3JcvWqMD67YzC5SKlMqofyfck1ebLh2zzlpD4hVQ3xiuuiADk4jNs0rTezVlxCMqOlZfA==",
+      "version": "8.8.3",
+      "resolved": "https://registry.npmjs.org/get-it/-/get-it-8.8.3.tgz",
+      "integrity": "sha512-IfkbWqOGO2kd2Ccgiz/NIzk3bcwjtVqBm3RNa3j/veHg2q7c1DgS3EXrCrvIWH0jbNTbhkdblnxBP7Dm8CiH+A==",
       "license": "MIT",
       "dependencies": {
         "decompress-response": "^7.0.0",
@@ -4366,6 +4810,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-random-values": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/get-random-values/-/get-random-values-1.2.2.tgz",
+      "integrity": "sha512-lMyPjQyl0cNNdDf2oR+IQ/fM3itDvpoHy45Ymo2r0L1EjazeSl13SfbKZs7KtZ/3MDCeueiaJiuOEfKqRTsSgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": "10 || 12 || >=14"
+      }
+    },
+    "node_modules/get-random-values-esm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-random-values-esm/-/get-random-values-esm-1.0.2.tgz",
+      "integrity": "sha512-HMSDTgj1HPFAuZG0FqxzHbYt5JeEGDUeT9r1RLXhS6RZQS8rLRjokgjZ0Pd28CN0lhXlRwfH6eviZqZEJ2kIoA==",
+      "deprecated": "use crypto.getRandomValues() instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-random-values": "^1.2.2"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4417,6 +4885,17 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "node_modules/globals": {
@@ -4479,6 +4958,19 @@
       },
       "peerDependencies": {
         "graphql": "14 - 16"
+      }
+    },
+    "node_modules/groq-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/groq-js/-/groq-js-2.0.0.tgz",
+      "integrity": "sha512-kj56ZjnOFbgDt91zYwQ10jsVUtVGJqAKfRbAir0EvTK84O5ZsSyc0rDEm2P3jmAJkxs4X1DOG8vtaYJQIA/XCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obug": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=22.12"
       }
     },
     "node_modules/has-bigints": {
@@ -4598,6 +5090,19 @@
       "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
       "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w=="
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-tokenize": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
@@ -4621,6 +5126,13 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/humanize-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/humanize-list/-/humanize-list-1.0.1.tgz",
+      "integrity": "sha512-4+p3fCRF21oUqxhK0yZ6yaSP/H5/wZumc7q1fH99RkW7Q13aAxDeP78BKjoR+6y+kaHqKF/JWuQhsNuuI2NKtA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/husky": {
       "version": "7.0.4",
@@ -4954,6 +5466,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5169,6 +5688,95 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5255,6 +5863,19 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/leven": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-4.1.0.tgz",
+      "integrity": "sha512-KZ9W9nWDT7rF7Dazg8xyLHGLrmpgq2nVNFUckhqdW3szVP6YhCpp/RAnpmVExA9JvrMynjwSLVrEj3AepHR6ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/levn": {
@@ -5449,6 +6070,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5587,6 +6222,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5655,6 +6297,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -5693,15 +6345,16 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -5973,6 +6626,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -6095,6 +6762,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6210,6 +6890,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -6395,6 +7085,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -6561,6 +7261,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -6626,6 +7339,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/sha256-uint8array": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/sha256-uint8array/-/sha256-uint8array-0.10.7.tgz",
+      "integrity": "sha512-1Q6JQU4tX9NqsDGodej6pkrUVQVNapLZnvkwIhddH/JqzBZF1fSaxSWNY6sziXBE8aEa2twtGkXUrwzGeZCMpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -7066,6 +7786,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -7125,6 +7852,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7135,6 +7882,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -7347,6 +8107,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -7445,6 +8215,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wavesurfer.js": {
       "version": "7.12.7",
       "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.12.7.tgz",
@@ -7454,6 +8237,16 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -7645,6 +8438,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@next/eslint-plugin-next": "^16.2.6",
+    "@sanity/block-tools": "^3.70.0",
+    "@sanity/schema": "^6.10.0",
     "@types/node": "^20.10.0",
     "@types/react": "^18.3.3",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
@@ -48,6 +50,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "husky": "^7.0.4",
+    "jsdom": "^29.1.1",
     "lint-staged": "^12.3.2",
     "prettier": "2.5.1",
     "typescript": "^5.3.3"

--- a/scripts/migrate-wordpress-blog.mjs
+++ b/scripts/migrate-wordpress-blog.mjs
@@ -22,10 +22,22 @@
  * Requires dev dependencies: @sanity/block-tools, @sanity/schema, jsdom.
  */
 
+import crypto from 'node:crypto'
+
 import { htmlToBlocks } from '@sanity/block-tools'
 import { createClient } from '@sanity/client'
 import { Schema } from '@sanity/schema'
 import { JSDOM } from 'jsdom'
+
+// Deterministic, valid Sanity document id. Slugs can exceed Sanity's 128-char
+// id limit, so long ones are truncated + suffixed with a short stable hash.
+// The slug field itself (the URL) is kept intact.
+const docId = (slug) => {
+  const id = `blogPost-${slug}`
+  if (id.length <= 120) return id
+  const hash = crypto.createHash('sha1').update(slug).digest('hex').slice(0, 8)
+  return `blogPost-${slug.slice(0, 100)}-${hash}`
+}
 
 const WP_API = 'https://www.orcasound.net/wp-json/wp/v2/posts'
 const PROJECT_ID = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || 'tncpl9l7'
@@ -104,7 +116,8 @@ async function uploadImage(url) {
     return null
   }
   try {
-    const res = await fetch(url)
+    // Time out slow/hanging image URLs so one bad image can't stall the run.
+    const res = await fetch(url, { signal: AbortSignal.timeout(20000) })
     if (!res.ok) throw new Error(`${res.status}`)
     const buffer = Buffer.from(await res.arrayBuffer())
     const filename = decodeURIComponent(
@@ -170,7 +183,7 @@ async function migratePost(post) {
   )
 
   const document = {
-    _id: `blogPost-${slug}`,
+    _id: docId(slug),
     _type: 'blogPost',
     title,
     slug: { _type: 'slug', current: slug },
@@ -212,12 +225,30 @@ async function main() {
   const limit = Number(process.env.LIMIT) || 0
   const posts = limit > 0 ? all.slice(0, limit) : all
   console.log(
-    `Fetched ${all.length} posts from WordPress${limit > 0 ? `, migrating first ${posts.length} (LIMIT=${limit})` : ''}.\n`
+    `Fetched ${all.length} posts from WordPress${
+      limit > 0 ? `, migrating first ${posts.length} (LIMIT=${limit})` : ''
+    }.\n`
   )
+
+  // Skip posts already migrated (safe to re-run / resume) unless FORCE=1.
+  let existing = new Set()
+  if (!DRY_RUN && !process.env.FORCE) {
+    try {
+      const ids = await client.fetch(`*[_type == "blogPost"].slug.current`)
+      existing = new Set(ids || [])
+    } catch {
+      existing = new Set()
+    }
+  }
 
   let ok = 0
   let failed = 0
+  let skipped = 0
   for (const post of posts) {
+    if (existing.has(post.slug)) {
+      skipped += 1
+      continue
+    }
     try {
       await migratePost(post)
       ok += 1
@@ -228,7 +259,7 @@ async function main() {
   }
 
   console.log(
-    `\nDone. ${ok} migrated, ${failed} failed, ${posts.length} total.`
+    `\nDone. ${ok} migrated, ${skipped} skipped (already present), ${failed} failed, ${posts.length} total.`
   )
 }
 

--- a/scripts/migrate-wordpress-blog.mjs
+++ b/scripts/migrate-wordpress-blog.mjs
@@ -208,8 +208,12 @@ async function main() {
       DRY_RUN ? '[DRY RUN] ' : ''
     }Migrating WordPress blog -> Sanity (${PROJECT_ID}/${DATASET})`
   )
-  const posts = await fetchAllPosts()
-  console.log(`Fetched ${posts.length} posts from WordPress.\n`)
+  const all = await fetchAllPosts()
+  const limit = Number(process.env.LIMIT) || 0
+  const posts = limit > 0 ? all.slice(0, limit) : all
+  console.log(
+    `Fetched ${all.length} posts from WordPress${limit > 0 ? `, migrating first ${posts.length} (LIMIT=${limit})` : ''}.\n`
+  )
 
   let ok = 0
   let failed = 0

--- a/scripts/migrate-wordpress-blog.mjs
+++ b/scripts/migrate-wordpress-blog.mjs
@@ -1,0 +1,234 @@
+/**
+ * One-time migration: WordPress blog -> Sanity (issue #397).
+ *
+ * Pulls every post from the orcasound.net WordPress REST API, converts the HTML
+ * body to Portable Text, uploads the featured image and any inline images to
+ * Sanity, and writes each post as a `blogPost` document. The original slug is
+ * preserved so existing /blog/<slug> links keep working.
+ *
+ * Usage:
+ *   1. Deploy the blogPost schema first:  (in studio/)  npx sanity deploy
+ *   2. Create a Sanity API token with write access (Editor).
+ *   3. Run:
+ *        SANITY_WRITE_TOKEN=xxxxx node scripts/migrate-wordpress-blog.mjs
+ *
+ *   Dry run (no token needed — fetches + converts, writes nothing, uploads
+ *   nothing, so inline body images are skipped):
+ *        DRY_RUN=1 node scripts/migrate-wordpress-blog.mjs
+ *
+ * Re-running is safe: each document uses a deterministic id (blogPost-<slug>)
+ * and is created-or-replaced.
+ *
+ * Requires dev dependencies: @sanity/block-tools, @sanity/schema, jsdom.
+ */
+
+import { htmlToBlocks } from '@sanity/block-tools'
+import { createClient } from '@sanity/client'
+import { Schema } from '@sanity/schema'
+import { JSDOM } from 'jsdom'
+
+const WP_API = 'https://www.orcasound.net/wp-json/wp/v2/posts'
+const PROJECT_ID = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || 'tncpl9l7'
+const DATASET = process.env.NEXT_PUBLIC_SANITY_DATASET || 'production'
+const TOKEN = process.env.SANITY_WRITE_TOKEN
+const DRY_RUN = Boolean(process.env.DRY_RUN)
+
+if (!DRY_RUN && !TOKEN) {
+  console.error(
+    'Missing SANITY_WRITE_TOKEN. Set it to a write-enabled Sanity token, or run with DRY_RUN=1.'
+  )
+  process.exit(1)
+}
+
+const client = createClient({
+  projectId: PROJECT_ID,
+  dataset: DATASET,
+  apiVersion: '2024-01-01',
+  token: TOKEN,
+  useCdn: false,
+})
+
+// Compile the block content type so block-tools knows how to shape the body.
+const blockContentType = Schema.compile({
+  name: 'blog',
+  types: [
+    {
+      name: 'blogPost',
+      type: 'document',
+      fields: [
+        {
+          name: 'body',
+          type: 'array',
+          of: [{ type: 'block' }, { type: 'image' }],
+        },
+      ],
+    },
+  ],
+})
+  .get('blogPost')
+  .fields.find((f) => f.name === 'body').type
+
+const parseHtml = (html) => new JSDOM(html).window.document
+
+const decodeEntities = (html) =>
+  new JSDOM(`<!doctype html><body>${html || ''}`).window.document.body
+    .textContent || ''
+
+const stripHtml = (html) => decodeEntities(html).replace(/\s+/g, ' ').trim()
+
+async function fetchAllPosts() {
+  const posts = []
+  let page = 1
+  for (;;) {
+    const url = `${WP_API}?per_page=100&page=${page}&_embed=1`
+    const res = await fetch(url)
+    if (res.status === 400) break // past the last page
+    if (!res.ok) throw new Error(`WP fetch failed: ${res.status} ${url}`)
+    const batch = await res.json()
+    if (!Array.isArray(batch) || batch.length === 0) break
+    posts.push(...batch)
+    const totalPages = Number(res.headers.get('x-wp-totalpages') || '1')
+    if (page >= totalPages) break
+    page += 1
+  }
+  return posts
+}
+
+// Upload an image URL to Sanity once; cache by URL so repeated srcs reuse it.
+const assetCache = new Map()
+async function uploadImage(url) {
+  if (!url) return null
+  if (assetCache.has(url)) return assetCache.get(url)
+  if (DRY_RUN) {
+    assetCache.set(url, null)
+    return null
+  }
+  try {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`${res.status}`)
+    const buffer = Buffer.from(await res.arrayBuffer())
+    const filename = decodeURIComponent(
+      url.split('/').pop().split('?')[0] || 'image'
+    )
+    const asset = await client.assets.upload('image', buffer, { filename })
+    assetCache.set(url, asset._id)
+    return asset._id
+  } catch (err) {
+    console.warn(`  ! image upload failed (${url}): ${err.message}`)
+    assetCache.set(url, null)
+    return null
+  }
+}
+
+function imageRule(imageMap) {
+  return {
+    deserialize(el, next, block) {
+      if (!el.tagName || el.tagName.toLowerCase() !== 'img') return undefined
+      const src = el.getAttribute('src')
+      const assetId = imageMap.get(src)
+      if (!assetId) return undefined
+      return block({
+        _type: 'image',
+        asset: { _type: 'reference', _ref: assetId },
+        alt: el.getAttribute('alt') || undefined,
+      })
+    },
+  }
+}
+
+async function migratePost(post) {
+  const slug = post.slug
+  const title = stripHtml(post.title?.rendered)
+  const contentHtml = post.content?.rendered || ''
+
+  // Pre-upload every inline body image so the (synchronous) block-tools rule
+  // can look up an already-uploaded asset id.
+  const doc = parseHtml(contentHtml)
+  const imageMap = new Map()
+  const imgEls = Array.from(doc.querySelectorAll('img'))
+  for (const img of imgEls) {
+    const src = img.getAttribute('src')
+    if (src) imageMap.set(src, await uploadImage(src))
+  }
+
+  const body = htmlToBlocks(contentHtml, blockContentType, {
+    parseHtml,
+    rules: [imageRule(imageMap)],
+  })
+
+  const featuredUrl =
+    post._embedded?.['wp:featuredmedia']?.[0]?.source_url || null
+  const featuredAssetId = await uploadImage(featuredUrl)
+
+  const tags = Array.from(
+    new Set(
+      (post._embedded?.['wp:term'] || [])
+        .flat()
+        .map((t) => t?.name)
+        .filter(Boolean)
+    )
+  )
+
+  const document = {
+    _id: `blogPost-${slug}`,
+    _type: 'blogPost',
+    title,
+    slug: { _type: 'slug', current: slug },
+    publishedAt: post.date_gmt ? `${post.date_gmt}Z` : post.date,
+    excerpt: stripHtml(post.excerpt?.rendered),
+    tags,
+    body,
+    ...(featuredAssetId
+      ? {
+          featuredImage: {
+            _type: 'image',
+            asset: { _type: 'reference', _ref: featuredAssetId },
+            alt: title,
+          },
+        }
+      : {}),
+  }
+
+  if (DRY_RUN) {
+    console.log(
+      `  [dry-run] ${slug} — ${body.length} blocks, ${
+        tags.length
+      } tags, featured:${Boolean(featuredUrl)}`
+    )
+    return
+  }
+
+  await client.createOrReplace(document)
+  console.log(`  ✓ ${slug} — ${body.length} blocks, ${tags.length} tags`)
+}
+
+async function main() {
+  console.log(
+    `${
+      DRY_RUN ? '[DRY RUN] ' : ''
+    }Migrating WordPress blog -> Sanity (${PROJECT_ID}/${DATASET})`
+  )
+  const posts = await fetchAllPosts()
+  console.log(`Fetched ${posts.length} posts from WordPress.\n`)
+
+  let ok = 0
+  let failed = 0
+  for (const post of posts) {
+    try {
+      await migratePost(post)
+      ok += 1
+    } catch (err) {
+      failed += 1
+      console.error(`  ✗ ${post.slug}: ${err.message}`)
+    }
+  }
+
+  console.log(
+    `\nDone. ${ok} migrated, ${failed} failed, ${posts.length} total.`
+  )
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/components/Blog/BlogListing.jsx
+++ b/src/components/Blog/BlogListing.jsx
@@ -1,0 +1,151 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  CardMedia,
+  Chip,
+  Container,
+  Pagination,
+  PaginationItem,
+  Stack,
+  Typography,
+} from '@mui/material'
+import Head from 'next/head'
+import Link from 'next/link'
+
+const formatDate = (value) => {
+  if (!value) return ''
+  const d = new Date(value)
+  return Number.isNaN(d.getTime())
+    ? ''
+    : d.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+}
+
+// Shared blog listing: the post grid plus numbered pagination (1 2 3 4). Used by
+// the /blog landing (page 1) and /blog/page/[page] (pages 2+). The final visual
+// design is pending UX handoff (#397); this is a simple, functional layout.
+export default function BlogListing({ posts, page, totalPages }) {
+  return (
+    <>
+      <Head>
+        <title>
+          {page > 1 ? `Blog (page ${page}) | Orcasound` : 'Blog | Orcasound'}
+        </title>
+        <meta
+          name="description"
+          content="News, updates, and stories from the Orcasound community."
+        />
+      </Head>
+
+      <Container maxWidth="lg" sx={{ py: { xs: 6, md: 10 } }}>
+        <Typography variant="h3" component="h1" gutterBottom>
+          Blog
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 5 }}>
+          News, updates, and stories from the Orcasound community.
+        </Typography>
+
+        {posts.length === 0 ? (
+          <Typography variant="body1" color="text.secondary">
+            No posts yet. Check back soon.
+          </Typography>
+        ) : (
+          <>
+            <Box
+              sx={{
+                display: 'grid',
+                gap: 4,
+                gridTemplateColumns: {
+                  xs: '1fr',
+                  sm: 'repeat(2, 1fr)',
+                  md: 'repeat(3, 1fr)',
+                },
+              }}
+            >
+              {posts.map((post) => (
+                <Link
+                  key={post.slug}
+                  href={`/blog/${post.slug}`}
+                  style={{ textDecoration: 'none' }}
+                >
+                  <Card
+                    sx={{
+                      height: '100%',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      transition: 'box-shadow 0.2s',
+                      '&:hover': { boxShadow: 6 },
+                    }}
+                  >
+                    {post.featuredImageUrl && (
+                      <CardMedia
+                        component="img"
+                        image={post.featuredImageUrl}
+                        alt={post.featuredImageAlt || post.title || ''}
+                        sx={{ aspectRatio: '16 / 9', objectFit: 'cover' }}
+                      />
+                    )}
+                    <CardContent sx={{ flexGrow: 1 }}>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        display="block"
+                        gutterBottom
+                      >
+                        {formatDate(post.publishedAt)}
+                      </Typography>
+                      <Typography variant="h6" component="h2" gutterBottom>
+                        {post.title}
+                      </Typography>
+                      {post.excerpt && (
+                        <Typography variant="body2" color="text.secondary">
+                          {post.excerpt}
+                        </Typography>
+                      )}
+                      {Array.isArray(post.tags) && post.tags.length > 0 && (
+                        <Stack
+                          direction="row"
+                          spacing={1}
+                          useFlexGap
+                          flexWrap="wrap"
+                          sx={{ mt: 2 }}
+                        >
+                          {post.tags.map((tag) => (
+                            <Chip key={tag} label={tag} size="small" />
+                          ))}
+                        </Stack>
+                      )}
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </Box>
+
+            {totalPages > 1 && (
+              <Stack alignItems="center" sx={{ mt: 6 }}>
+                <Pagination
+                  count={totalPages}
+                  page={page}
+                  color="primary"
+                  renderItem={(item) => (
+                    <PaginationItem
+                      component={Link}
+                      href={
+                        item.page === 1 ? '/blog' : `/blog/page/${item.page}`
+                      }
+                      {...item}
+                    />
+                  )}
+                />
+              </Stack>
+            )}
+          </>
+        )}
+      </Container>
+    </>
+  )
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -95,15 +95,9 @@ const sendFeedbackLink = (
 )
 
 const blogLink = (
-  <StyledTypography
-    variant="h6"
-    component="a"
-    href="https://www.orcasound.net/blog/"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Blog
-  </StyledTypography>
+  <Link href="/blog">
+    <StyledTypography variant="h6">Blog</StyledTypography>
+  </Link>
 )
 
 const supportUsLink = (
@@ -157,9 +151,8 @@ const navLinksRightCol = [
   },
   {
     name: 'Blog',
-    url: 'https://www.orcasound.net/blog/',
+    url: '/blog',
     icon: '',
-    external: true,
   },
 ]
 

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -48,9 +48,8 @@ const navLinks = [
   },
   {
     name: 'Blog',
-    url: 'https://www.orcasound.net/blog/',
+    url: '/blog',
     icon: '',
-    external: true,
   },
   {
     name: 'Send Feedback',

--- a/src/pages/blog/[slug].jsx
+++ b/src/pages/blog/[slug].jsx
@@ -10,11 +10,8 @@ import { PortableText } from '@portabletext/react'
 import Head from 'next/head'
 import Image from 'next/image'
 
-import TopBanner from '../../components/TopBanner'
 import { getClient } from '../../sanity/client'
 import { BLOG_POST_QUERY, BLOG_SLUGS_QUERY } from '../../sanity/queries'
-
-const POST_BODY_ID = 'post-body'
 
 const formatDate = (value) => {
   if (!value) return ''
@@ -128,29 +125,27 @@ export default function BlogPost({ post }) {
         {post.excerpt && <meta name="description" content={post.excerpt} />}
       </Head>
 
-      {post.featuredImageUrl ? (
-        <TopBanner
-          bannerImg={post.featuredImageUrl}
-          pageTitle={post.title}
-          pageDesc={dateLabel}
-          scrollToId={POST_BODY_ID}
-        />
-      ) : (
-        <Container maxWidth="md" sx={{ pt: { xs: 6, md: 8 } }}>
-          <Typography variant="h3" component="h1" gutterBottom>
-            {post.title}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {dateLabel}
-          </Typography>
-        </Container>
-      )}
-
       <Container
+        component="article"
         maxWidth="md"
-        id={POST_BODY_ID}
-        sx={{ py: { xs: 6, md: 8 }, scrollMarginTop: '80px' }}
+        sx={{ py: { xs: 5, md: 8 } }}
       >
+        <MuiLink
+          href="/blog"
+          variant="body2"
+          sx={{ display: 'inline-block', mb: 3 }}
+        >
+          &larr; Back to all posts
+        </MuiLink>
+
+        <Typography variant="h3" component="h1" gutterBottom>
+          {post.title}
+        </Typography>
+
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          {dateLabel}
+        </Typography>
+
         {Array.isArray(post.tags) && post.tags.length > 0 && (
           <Stack
             direction="row"
@@ -165,13 +160,29 @@ export default function BlogPost({ post }) {
           </Stack>
         )}
 
+        {post.featuredImageUrl && (
+          <Box
+            sx={{
+              mb: 5,
+              borderRadius: 2,
+              overflow: 'hidden',
+              lineHeight: 0,
+            }}
+          >
+            <Image
+              src={post.featuredImageUrl}
+              alt={post.featuredImageAlt || post.title || ''}
+              width={1600}
+              height={900}
+              style={{ width: '100%', height: 'auto' }}
+              priority
+            />
+          </Box>
+        )}
+
         {Array.isArray(post.body) && (
           <PortableText value={post.body} components={portableComponents} />
         )}
-
-        <Box sx={{ mt: 6 }}>
-          <MuiLink href="/blog">&larr; Back to all posts</MuiLink>
-        </Box>
       </Container>
     </>
   )

--- a/src/pages/blog/[slug].jsx
+++ b/src/pages/blog/[slug].jsx
@@ -1,0 +1,207 @@
+import {
+  Box,
+  Chip,
+  Container,
+  Link as MuiLink,
+  Stack,
+  Typography,
+} from '@mui/material'
+import { PortableText } from '@portabletext/react'
+import Head from 'next/head'
+import Image from 'next/image'
+
+import TopBanner from '../../components/TopBanner'
+import { getClient } from '../../sanity/client'
+import { BLOG_POST_QUERY, BLOG_SLUGS_QUERY } from '../../sanity/queries'
+
+const POST_BODY_ID = 'post-body'
+
+const formatDate = (value) => {
+  if (!value) return ''
+  const d = new Date(value)
+  return Number.isNaN(d.getTime())
+    ? ''
+    : d.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+}
+
+// Render Portable Text with the site's typography, matching the other Sanity
+// pages. Supports headings, lists, links, and inline images.
+const portableComponents = {
+  block: {
+    normal: ({ children }) => (
+      <Typography variant="body1" paragraph>
+        {children}
+      </Typography>
+    ),
+    h2: ({ children }) => (
+      <Typography variant="h4" component="h2" sx={{ mt: 5, mb: 2 }}>
+        {children}
+      </Typography>
+    ),
+    h3: ({ children }) => (
+      <Typography variant="h5" component="h3" sx={{ mt: 4, mb: 2 }}>
+        {children}
+      </Typography>
+    ),
+    blockquote: ({ children }) => (
+      <Box
+        component="blockquote"
+        sx={{
+          borderLeft: '4px solid',
+          borderColor: 'primary.main',
+          pl: 2,
+          my: 3,
+          color: 'text.secondary',
+          fontStyle: 'italic',
+        }}
+      >
+        {children}
+      </Box>
+    ),
+  },
+  list: {
+    bullet: ({ children }) => (
+      <Box component="ul" sx={{ pl: 3, mb: 2 }}>
+        {children}
+      </Box>
+    ),
+    number: ({ children }) => (
+      <Box component="ol" sx={{ pl: 3, mb: 2 }}>
+        {children}
+      </Box>
+    ),
+  },
+  listItem: {
+    bullet: ({ children }) => (
+      <Typography component="li" variant="body1">
+        {children}
+      </Typography>
+    ),
+    number: ({ children }) => (
+      <Typography component="li" variant="body1">
+        {children}
+      </Typography>
+    ),
+  },
+  marks: {
+    link: ({ value, children }) => {
+      const href = value?.href || '#'
+      const external = /^https?:\/\//.test(href)
+      return (
+        <MuiLink
+          href={href}
+          target={external ? '_blank' : undefined}
+          rel={external ? 'noopener noreferrer' : undefined}
+        >
+          {children}
+        </MuiLink>
+      )
+    },
+  },
+  types: {
+    image: ({ value }) =>
+      value?.url ? (
+        <Box sx={{ my: 4 }}>
+          <Image
+            src={value.url}
+            alt={value.alt || ''}
+            width={1200}
+            height={800}
+            style={{ width: '100%', height: 'auto', borderRadius: 8 }}
+          />
+        </Box>
+      ) : null,
+  },
+}
+
+export default function BlogPost({ post }) {
+  const dateLabel = formatDate(post.publishedAt)
+
+  return (
+    <>
+      <Head>
+        <title>{post.title} | Orcasound Blog</title>
+        {post.excerpt && <meta name="description" content={post.excerpt} />}
+      </Head>
+
+      {post.featuredImageUrl ? (
+        <TopBanner
+          bannerImg={post.featuredImageUrl}
+          pageTitle={post.title}
+          pageDesc={dateLabel}
+          scrollToId={POST_BODY_ID}
+        />
+      ) : (
+        <Container maxWidth="md" sx={{ pt: { xs: 6, md: 8 } }}>
+          <Typography variant="h3" component="h1" gutterBottom>
+            {post.title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {dateLabel}
+          </Typography>
+        </Container>
+      )}
+
+      <Container
+        maxWidth="md"
+        id={POST_BODY_ID}
+        sx={{ py: { xs: 6, md: 8 }, scrollMarginTop: '80px' }}
+      >
+        {Array.isArray(post.tags) && post.tags.length > 0 && (
+          <Stack
+            direction="row"
+            spacing={1}
+            useFlexGap
+            flexWrap="wrap"
+            sx={{ mb: 4 }}
+          >
+            {post.tags.map((tag) => (
+              <Chip key={tag} label={tag} size="small" />
+            ))}
+          </Stack>
+        )}
+
+        {Array.isArray(post.body) && (
+          <PortableText value={post.body} components={portableComponents} />
+        )}
+
+        <Box sx={{ mt: 6 }}>
+          <MuiLink href="/blog">&larr; Back to all posts</MuiLink>
+        </Box>
+      </Container>
+    </>
+  )
+}
+
+export async function getStaticPaths() {
+  let slugs = []
+  try {
+    slugs = (await getClient(false).fetch(BLOG_SLUGS_QUERY)) || []
+  } catch {
+    slugs = []
+  }
+  return {
+    paths: slugs.map((slug) => ({ params: { slug } })),
+    // 'blocking' so posts added in Sanity after build render without a rebuild.
+    fallback: 'blocking',
+  }
+}
+
+export async function getStaticProps({ params }) {
+  let post = null
+  try {
+    post = await getClient(false).fetch(BLOG_POST_QUERY, { slug: params.slug })
+  } catch {
+    post = null
+  }
+
+  if (!post) {
+    return { notFound: true, revalidate: 60 }
+  }
+
+  return { props: { post }, revalidate: 60 }
+}

--- a/src/pages/blog/index.jsx
+++ b/src/pages/blog/index.jsx
@@ -1,0 +1,138 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  CardMedia,
+  Chip,
+  Container,
+  Stack,
+  Typography,
+} from '@mui/material'
+import Head from 'next/head'
+import Link from 'next/link'
+
+import { getClient } from '../../sanity/client'
+import { BLOG_POSTS_QUERY } from '../../sanity/queries'
+
+const formatDate = (value) => {
+  if (!value) return ''
+  const d = new Date(value)
+  return Number.isNaN(d.getTime())
+    ? ''
+    : d.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+}
+
+// NOTE: This is a simple, functional landing layout. The final blog landing
+// design (post-list layout, tag filters) is pending UX handoff — see #397.
+export default function Blog({ posts }) {
+  return (
+    <>
+      <Head>
+        <title>Blog | Orcasound</title>
+        <meta
+          name="description"
+          content="News, updates, and stories from the Orcasound community."
+        />
+      </Head>
+
+      <Container maxWidth="lg" sx={{ py: { xs: 6, md: 10 } }}>
+        <Typography variant="h3" component="h1" gutterBottom>
+          Blog
+        </Typography>
+        <Typography variant="body1" color="text.secondary" sx={{ mb: 5 }}>
+          News, updates, and stories from the Orcasound community.
+        </Typography>
+
+        {posts.length === 0 ? (
+          <Typography variant="body1" color="text.secondary">
+            No posts yet. Check back soon.
+          </Typography>
+        ) : (
+          <Box
+            sx={{
+              display: 'grid',
+              gap: 4,
+              gridTemplateColumns: {
+                xs: '1fr',
+                sm: 'repeat(2, 1fr)',
+                md: 'repeat(3, 1fr)',
+              },
+            }}
+          >
+            {posts.map((post) => (
+              <Link
+                key={post.slug}
+                href={`/blog/${post.slug}`}
+                style={{ textDecoration: 'none' }}
+              >
+                <Card
+                  sx={{
+                    height: '100%',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    transition: 'box-shadow 0.2s',
+                    '&:hover': { boxShadow: 6 },
+                  }}
+                >
+                  {post.featuredImageUrl && (
+                    <CardMedia
+                      component="img"
+                      image={post.featuredImageUrl}
+                      alt={post.featuredImageAlt || post.title || ''}
+                      sx={{ aspectRatio: '16 / 9', objectFit: 'cover' }}
+                    />
+                  )}
+                  <CardContent sx={{ flexGrow: 1 }}>
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      display="block"
+                      gutterBottom
+                    >
+                      {formatDate(post.publishedAt)}
+                    </Typography>
+                    <Typography variant="h6" component="h2" gutterBottom>
+                      {post.title}
+                    </Typography>
+                    {post.excerpt && (
+                      <Typography variant="body2" color="text.secondary">
+                        {post.excerpt}
+                      </Typography>
+                    )}
+                    {Array.isArray(post.tags) && post.tags.length > 0 && (
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        useFlexGap
+                        flexWrap="wrap"
+                        sx={{ mt: 2 }}
+                      >
+                        {post.tags.map((tag) => (
+                          <Chip key={tag} label={tag} size="small" />
+                        ))}
+                      </Stack>
+                    )}
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </Box>
+        )}
+      </Container>
+    </>
+  )
+}
+
+export async function getStaticProps() {
+  let posts = []
+  try {
+    posts = (await getClient(false).fetch(BLOG_POSTS_QUERY)) || []
+  } catch {
+    posts = []
+  }
+  return { props: { posts }, revalidate: 60 }
+}

--- a/src/pages/blog/index.jsx
+++ b/src/pages/blog/index.jsx
@@ -1,138 +1,30 @@
-import {
-  Box,
-  Card,
-  CardContent,
-  CardMedia,
-  Chip,
-  Container,
-  Stack,
-  Typography,
-} from '@mui/material'
-import Head from 'next/head'
-import Link from 'next/link'
-
+import BlogListing from '../../components/Blog/BlogListing'
 import { getClient } from '../../sanity/client'
-import { BLOG_POSTS_QUERY } from '../../sanity/queries'
+import {
+  BLOG_POSTS_COUNT_QUERY,
+  BLOG_POSTS_PAGE_QUERY,
+  BLOG_POSTS_PER_PAGE,
+} from '../../sanity/queries'
 
-const formatDate = (value) => {
-  if (!value) return ''
-  const d = new Date(value)
-  return Number.isNaN(d.getTime())
-    ? ''
-    : d.toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      })
-}
-
-// NOTE: This is a simple, functional landing layout. The final blog landing
-// design (post-list layout, tag filters) is pending UX handoff — see #397.
-export default function Blog({ posts }) {
-  return (
-    <>
-      <Head>
-        <title>Blog | Orcasound</title>
-        <meta
-          name="description"
-          content="News, updates, and stories from the Orcasound community."
-        />
-      </Head>
-
-      <Container maxWidth="lg" sx={{ py: { xs: 6, md: 10 } }}>
-        <Typography variant="h3" component="h1" gutterBottom>
-          Blog
-        </Typography>
-        <Typography variant="body1" color="text.secondary" sx={{ mb: 5 }}>
-          News, updates, and stories from the Orcasound community.
-        </Typography>
-
-        {posts.length === 0 ? (
-          <Typography variant="body1" color="text.secondary">
-            No posts yet. Check back soon.
-          </Typography>
-        ) : (
-          <Box
-            sx={{
-              display: 'grid',
-              gap: 4,
-              gridTemplateColumns: {
-                xs: '1fr',
-                sm: 'repeat(2, 1fr)',
-                md: 'repeat(3, 1fr)',
-              },
-            }}
-          >
-            {posts.map((post) => (
-              <Link
-                key={post.slug}
-                href={`/blog/${post.slug}`}
-                style={{ textDecoration: 'none' }}
-              >
-                <Card
-                  sx={{
-                    height: '100%',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    transition: 'box-shadow 0.2s',
-                    '&:hover': { boxShadow: 6 },
-                  }}
-                >
-                  {post.featuredImageUrl && (
-                    <CardMedia
-                      component="img"
-                      image={post.featuredImageUrl}
-                      alt={post.featuredImageAlt || post.title || ''}
-                      sx={{ aspectRatio: '16 / 9', objectFit: 'cover' }}
-                    />
-                  )}
-                  <CardContent sx={{ flexGrow: 1 }}>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      display="block"
-                      gutterBottom
-                    >
-                      {formatDate(post.publishedAt)}
-                    </Typography>
-                    <Typography variant="h6" component="h2" gutterBottom>
-                      {post.title}
-                    </Typography>
-                    {post.excerpt && (
-                      <Typography variant="body2" color="text.secondary">
-                        {post.excerpt}
-                      </Typography>
-                    )}
-                    {Array.isArray(post.tags) && post.tags.length > 0 && (
-                      <Stack
-                        direction="row"
-                        spacing={1}
-                        useFlexGap
-                        flexWrap="wrap"
-                        sx={{ mt: 2 }}
-                      >
-                        {post.tags.map((tag) => (
-                          <Chip key={tag} label={tag} size="small" />
-                        ))}
-                      </Stack>
-                    )}
-                  </CardContent>
-                </Card>
-              </Link>
-            ))}
-          </Box>
-        )}
-      </Container>
-    </>
-  )
+export default function Blog({ posts, page, totalPages }) {
+  return <BlogListing posts={posts} page={page} totalPages={totalPages} />
 }
 
 export async function getStaticProps() {
   let posts = []
+  let total = 0
   try {
-    posts = (await getClient(false).fetch(BLOG_POSTS_QUERY)) || []
+    const client = getClient(false)
+    total = (await client.fetch(BLOG_POSTS_COUNT_QUERY)) || 0
+    posts =
+      (await client.fetch(BLOG_POSTS_PAGE_QUERY, {
+        start: 0,
+        end: BLOG_POSTS_PER_PAGE,
+      })) || []
   } catch {
     posts = []
+    total = 0
   }
-  return { props: { posts }, revalidate: 60 }
+  const totalPages = Math.max(1, Math.ceil(total / BLOG_POSTS_PER_PAGE))
+  return { props: { posts, page: 1, totalPages }, revalidate: 60 }
 }

--- a/src/pages/blog/page/[page].jsx
+++ b/src/pages/blog/page/[page].jsx
@@ -1,0 +1,60 @@
+import BlogListing from '../../../components/Blog/BlogListing'
+import { getClient } from '../../../sanity/client'
+import {
+  BLOG_POSTS_COUNT_QUERY,
+  BLOG_POSTS_PAGE_QUERY,
+  BLOG_POSTS_PER_PAGE,
+} from '../../../sanity/queries'
+
+export default function BlogPage({ posts, page, totalPages }) {
+  return <BlogListing posts={posts} page={page} totalPages={totalPages} />
+}
+
+export async function getStaticPaths() {
+  let total = 0
+  try {
+    total = (await getClient(false).fetch(BLOG_POSTS_COUNT_QUERY)) || 0
+  } catch {
+    total = 0
+  }
+  const totalPages = Math.ceil(total / BLOG_POSTS_PER_PAGE)
+  // Page 1 lives at /blog, so only generate 2..totalPages here.
+  const paths = []
+  for (let p = 2; p <= totalPages; p += 1) {
+    paths.push({ params: { page: String(p) } })
+  }
+  return { paths, fallback: 'blocking' }
+}
+
+export async function getStaticProps({ params }) {
+  const page = Number.parseInt(params.page, 10)
+
+  // Guard against invalid or page-1 URLs (page 1 canonically lives at /blog).
+  if (!Number.isInteger(page) || page < 2) {
+    return { notFound: true, revalidate: 60 }
+  }
+
+  let posts = []
+  let total = 0
+  try {
+    const client = getClient(false)
+    total = (await client.fetch(BLOG_POSTS_COUNT_QUERY)) || 0
+    posts =
+      (await client.fetch(BLOG_POSTS_PAGE_QUERY, {
+        start: (page - 1) * BLOG_POSTS_PER_PAGE,
+        end: page * BLOG_POSTS_PER_PAGE,
+      })) || []
+  } catch {
+    posts = []
+    total = 0
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / BLOG_POSTS_PER_PAGE))
+
+  // A page number past the end (e.g. after posts were deleted) → 404.
+  if (page > totalPages) {
+    return { notFound: true, revalidate: 60 }
+  }
+
+  return { props: { posts, page, totalPages }, revalidate: 60 }
+}

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -482,3 +482,18 @@ export interface BlogPost extends BlogPostListItem {
   // @portabletext/react rather than reading the shape directly.
   body?: unknown[]
 }
+
+/** Blog pagination (issue #397). Posts per page + a count and a sliced page query. */
+export const BLOG_POSTS_PER_PAGE = 9
+
+export const BLOG_POSTS_COUNT_QUERY = `count(*[_type == "blogPost" && defined(slug.current)])`
+
+export const BLOG_POSTS_PAGE_QUERY = `*[_type == "blogPost" && defined(slug.current)]|order(publishedAt desc)[$start...$end]{
+  title,
+  "slug": slug.current,
+  publishedAt,
+  excerpt,
+  "featuredImageUrl": featuredImage.asset->url,
+  "featuredImageAlt": featuredImage.alt,
+  tags
+}`

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -434,3 +434,51 @@ export interface DonatePartner {
   description?: string
   linkTo?: string
 }
+
+/**
+ * Blog (issue #397). List query for the /blog landing page and a single-post
+ * query for /blog/[slug]. Image assets resolve to plain CDN URLs via
+ * `asset->url`, matching the other Sanity pages. Body images are resolved
+ * inline so the Portable Text renderer can show them.
+ */
+export const BLOG_POSTS_QUERY = `*[_type == "blogPost" && defined(slug.current)]|order(publishedAt desc){
+  title,
+  "slug": slug.current,
+  publishedAt,
+  excerpt,
+  "featuredImageUrl": featuredImage.asset->url,
+  "featuredImageAlt": featuredImage.alt,
+  tags
+}`
+
+export const BLOG_SLUGS_QUERY = `*[_type == "blogPost" && defined(slug.current)].slug.current`
+
+export const BLOG_POST_QUERY = `*[_type == "blogPost" && slug.current == $slug][0]{
+  title,
+  "slug": slug.current,
+  publishedAt,
+  excerpt,
+  "featuredImageUrl": featuredImage.asset->url,
+  "featuredImageAlt": featuredImage.alt,
+  tags,
+  body[]{
+    ...,
+    _type == "image" => { "url": asset->url, alt }
+  }
+}`
+
+export interface BlogPostListItem {
+  title?: string
+  slug?: string
+  publishedAt?: string
+  excerpt?: string
+  featuredImageUrl?: string
+  featuredImageAlt?: string
+  tags?: string[]
+}
+
+export interface BlogPost extends BlogPostListItem {
+  // Portable Text blocks; typed loosely since the page renders them via
+  // @portabletext/react rather than reading the shape directly.
+  body?: unknown[]
+}

--- a/studio/schemaTypes/blogPost.tsx
+++ b/studio/schemaTypes/blogPost.tsx
@@ -1,0 +1,81 @@
+import {defineArrayMember, defineField, defineType} from 'sanity'
+
+/**
+ * A single blog post migrated from WordPress (issue #397). Minimal, additive
+ * schema that renders now with a simple layout and stays flexible for the
+ * pending UX design: title + slug + date + excerpt + featured image + tags +
+ * a Portable Text body (rich text with inline images).
+ */
+export const blogPost = defineType({
+  name: 'blogPost',
+  title: 'Blog Post',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'slug',
+      title: 'Slug',
+      description:
+        'The URL path segment, e.g. /blog/<slug>. Preserve the original WordPress slug where practical to keep existing links working.',
+      type: 'slug',
+      options: {source: 'title', maxLength: 96},
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'publishedAt',
+      title: 'Published date',
+      type: 'datetime',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'excerpt',
+      title: 'Excerpt / description',
+      description:
+        'Short summary shown in the blog listing and used as the page meta description.',
+      type: 'text',
+      rows: 3,
+    }),
+    defineField({
+      name: 'featuredImage',
+      title: 'Featured image',
+      type: 'image',
+      options: {hotspot: true},
+      fields: [defineField({name: 'alt', title: 'Alt text', type: 'string'})],
+    }),
+    defineField({
+      name: 'tags',
+      title: 'Tags',
+      type: 'array',
+      of: [defineArrayMember({type: 'string'})],
+      options: {layout: 'tags'},
+    }),
+    defineField({
+      name: 'body',
+      title: 'Body',
+      type: 'array',
+      of: [
+        defineArrayMember({type: 'block'}),
+        defineArrayMember({
+          type: 'image',
+          options: {hotspot: true},
+          fields: [defineField({name: 'alt', title: 'Alt text', type: 'string'})],
+        }),
+      ],
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Published date, newest first',
+      name: 'publishedAtDesc',
+      by: [{field: 'publishedAt', direction: 'desc'}],
+    },
+  ],
+  preview: {
+    select: {title: 'title', subtitle: 'publishedAt', media: 'featuredImage'},
+  },
+})

--- a/studio/schemaTypes/index.ts
+++ b/studio/schemaTypes/index.ts
@@ -1,4 +1,5 @@
 import {aboutPage} from './aboutPage'
+import {blogPost} from './blogPost'
 import {catalogPage} from './catalogPage'
 import {contributor} from './contributor'
 import {donatePage} from './donatePage'
@@ -16,4 +17,5 @@ export const schemaTypes = [
   hackerHallOfFamePage,
   catalogPage,
   donatePage,
+  blogPost,
 ]


### PR DESCRIPTION
## What

Implements the **dev scope of #397** (blog → Sanity), so the blog can live in the Next.js Orcahome site instead of WordPress.

- **Sanity schema** `blogPost` (`studio/schemaTypes/blogPost.tsx`): title, slug, publishedAt, excerpt, featuredImage (with alt), tags, and a Portable Text `body` that supports inline images. Registered in the studio schema index.
- **Queries** (`src/sanity/queries.ts`): list, slugs, and single-post GROQ queries; image assets resolve to CDN URLs via `asset->url`, matching the other pages.
- **`/blog` landing** (`src/pages/blog/index.jsx`): a simple, functional post-list (featured image, date, title, excerpt, tags) — the **final landing design is pending UX handoff** (noted in-code and in #397), so this is intentionally minimal.
- **`/blog/[slug]` post page** (`src/pages/blog/[slug].jsx`): renders the **featured image as a TopBanner hero** (matching every other page) plus the Portable Text body with the site's typography. `getStaticPaths` + `fallback: 'blocking'` so new posts render without a rebuild.

Follows the existing Sanity pattern (`getClient(false).fetch` in `getStaticProps`, try/catch fallback, `revalidate: 60`). With no content, `/blog` shows an empty state and posts 404 — nothing breaks.

## Screenshots

Verified locally with mock content (mock reverted before commit): the landing renders an on-brand 3-up card grid, and a post renders the featured-image hero + body consistent with the rest of the site.

## Not in this PR (follow-ups under #397)

- **WordPress → Sanity import script** (programmatic migration of existing posts, preserving slugs/dates/images/tags).
- Removing the site's temporary links to the WordPress blog once content is migrated.
- Final landing-page visual design (pending UX handoff).

## Note

The `blogPost` schema needs a Studio deploy (`npx sanity deploy`) before it appears in the Studio for editing.

Part of #341. Implements the dev scope of #397.


---

## Update: WordPress migration + pagination

- **Migration script** `scripts/migrate-wordpress-blog.mjs`: pulls all posts from the orcasound.net WordPress REST API, converts each HTML body to Portable Text (`@sanity/block-tools` + `jsdom`), uploads the featured and inline images to Sanity, and writes `blogPost` documents with the **original slug preserved**. Idempotent (deterministic `_id` per slug, create-or-replace).
  - **Dry-run verified against all 97 live posts** (`DRY_RUN=1 node scripts/migrate-wordpress-blog.mjs`) — 97 converted, 0 failed. Dry run needs no token and skips uploads/writes.
  - To actually import: deploy the schema (`npx sanity deploy` in `studio/`), create a write-enabled Sanity token, then `SANITY_WRITE_TOKEN=xxx node scripts/migrate-wordpress-blog.mjs`.
- **Pagination**: `/blog` is page 1 and `/blog/page/[page]` serves pages 2+, **9 posts per page**, via a shared `BlogListing` component with numbered MUI pagination (1 2 3 …).
- Adds dev deps `@sanity/block-tools`, `@sanity/schema`, `jsdom` (used only by the script).

**Reviewer note:** the WordPress→Sanity content conversion should get a spot-check on a few posts after the real import (body formatting, images, tags), since HTML→Portable Text can't perfectly preserve every WordPress construct.
