### PR TITLE
docs: add a Sanity overview guide (how to update the site)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ cp .env.example .env.local
 
 `.env.local` is gitignored. The app is designed to build without these set — Sanity is created lazily, and a friendly error only surfaces if a preview route is hit while unconfigured. See [`.env.example`](.env.example) for the full list and where to get a read token.
 
+### Editing content in Sanity
+
+Content (page copy, images, blog posts) is managed in Sanity — no code needed. See [`docs/sanity-guide.md`](docs/sanity-guide.md) for the overview and per-page guides. (For non-technical editors, the authoritative guides are the Google Doc versions in the shared Drive folder.)
+
 ## Available scripts
 
 | Script                 | Description                              |

--- a/docs/sanity-guide.md
+++ b/docs/sanity-guide.md
@@ -14,7 +14,8 @@ below.
 
 1. Go to **https://orcahome.sanity.studio**
 2. Sign in with the Google account that was given access. If you can't get in,
-   ask an admin to grant your account access — ping @Vicky on Zulip.
+   ask to have your account added to the Sanity project. Brendan Thatcher owns
+   the project; ping @Vicky or @Brendan on Zulip.
 
 ---
 

--- a/docs/sanity-guide.md
+++ b/docs/sanity-guide.md
@@ -1,0 +1,89 @@
+# Updating the website with Sanity (overview)
+
+The content on orcasound.tech is managed in **Sanity**, a content management
+system (CMS). You edit everything in the **Sanity Studio** (a website) and your
+changes go live automatically — you do not touch code, and you do not need a
+developer to deploy anything.
+
+This page is the overview. Each page has its own step-by-step guide, linked
+below.
+
+---
+
+## 1. Getting in
+
+1. Go to **https://orcahome.sanity.studio**
+2. Sign in with the Google account that was given access. If you can't get in,
+   ask an admin to grant your account access — ping @Vicky on Zulip.
+
+---
+
+## 2. Two kinds of content
+
+### Fixed pages
+
+Each main page is a single document in the Studio — you edit its fields (text,
+images, lists). Pick the page you want to edit:
+
+| Page                | Guide                                                            |
+| ------------------- | ---------------------------------------------------------------- |
+| Home                | [editing-home-content.md](editing-home-content.md)               |
+| About               | [editing-about-content.md](editing-about-content.md)             |
+| Learn               | [editing-learn-content.md](editing-learn-content.md)             |
+| Call Catalog        | [editing-catalog-content.md](editing-catalog-content.md)         |
+| Get Involved        | [editing-getinvolved-content.md](editing-getinvolved-content.md) |
+| Hacker Hall of Fame | [editing-hhof-content.md](editing-hhof-content.md)               |
+| Donate / Support    | [editing-donate-content.md](editing-donate-content.md)           |
+
+### Blog
+
+The blog is different: it's a **collection of posts** you can add, edit, and
+publish yourself (not a single fixed document). See
+[editing-blog-content.md](editing-blog-content.md).
+
+---
+
+## 3. Rules that apply everywhere
+
+These are the same no matter which page or post you're editing:
+
+- **You must Publish.** Nothing goes live until you click the green **Publish**
+  button. If you see "Unpublished changes", your edits are not live yet — click
+  Publish. Don't leave edits sitting as an unpublished draft.
+- **Empty fields fall back to defaults.** If you leave a field blank, the site
+  shows its built-in default text/image — nothing breaks. Fill the field in to
+  override it.
+- **Images:** click the image field, remove the current image, then drag in or
+  upload a new one. You can drag the crop/hotspot to control framing.
+- **Going live takes ~1 minute.** After you publish, refresh the page with a
+  hard refresh (Cmd/Ctrl + Shift + R) to see the change.
+- **Don't change existing links/slugs.** For the blog especially, changing a
+  post's slug changes its web address and breaks existing links to it.
+
+---
+
+## 4. For developers
+
+Most of the above is content only. A few things do need a developer:
+
+- **Content vs. code:** Sanity holds the editable content. Page layout, styling,
+  and behavior stay in the React code (`src/`). Editing content never touches
+  code.
+- **Schema changes need a deploy.** The _fields_ an editor sees are defined in
+  `studio/schemaTypes/`. If you add/rename/remove a field (or a whole document
+  type), run `npx sanity deploy` from `studio/` so the Studio picks it up.
+  (Editing content values does **not** need a deploy — only schema/structure
+  changes do.)
+- **Environment variables** (already set in Vercel):
+  - `NEXT_PUBLIC_SANITY_PROJECT_ID`
+  - `NEXT_PUBLIC_SANITY_DATASET`
+  - `NEXT_PUBLIC_SANITY_API_VERSION`
+  - `SANITY_API_READ_TOKEN` (server-only; used to preview draft content)
+- **How pages read Sanity:** each page fetches its document in `getStaticProps`
+  via `getClient` (`src/sanity/`), with per-field fallback to the built-in
+  default, so a page still renders even if a field (or the whole dataset) is
+  empty.
+
+---
+
+_Questions or something looks broken? ping @Vicky on Zulip._

--- a/docs/sanity-guide.md
+++ b/docs/sanity-guide.md
@@ -1,5 +1,9 @@
 # Updating the website with Sanity (overview)
 
+> **Editors:** this Markdown file is a repository reference. The authoritative,
+> up-to-date guides for editors are the **Google Doc versions** in the shared
+> Drive folder. If the two ever differ, the Google Docs win.
+
 The content on orcasound.tech is managed in **Sanity**, a content management
 system (CMS). You edit everything in the **Sanity Studio** (a website) and your
 changes go live automatically — you do not touch code, and you do not need a

--- a/studio/components/EditingGuidePane.tsx
+++ b/studio/components/EditingGuidePane.tsx
@@ -1,0 +1,34 @@
+import {Box, Card, Heading, Stack, Text} from '@sanity/ui'
+
+/**
+ * A small help pane shown from the "📖 Start here" item at the top of the
+ * Studio content list. Sidebar list items can't be plain external links, so
+ * this renders a one-line intro plus a link that opens the editor-facing guide
+ * (the Google Doc) in a new tab.
+ */
+const GUIDE_URL =
+  'https://docs.google.com/document/d/1ESex1obpVYf7skclCcjbJx8g0W4ruv6TG77c7yXCONU/edit'
+
+export function EditingGuidePane() {
+  return (
+    <Box padding={4}>
+      <Card padding={4} radius={3} shadow={1}>
+        <Stack space={4}>
+          <Heading size={2}>📖 Start here</Heading>
+          <Text size={2}>
+            New to editing the site? This Studio is where you change page content
+            and write blog posts. Nothing goes live until you click Publish.
+          </Text>
+          <Text size={2}>
+            <a href={GUIDE_URL} target="_blank" rel="noreferrer">
+              Open the editing guide ↗
+            </a>
+          </Text>
+          <Text size={1} muted>
+            Each page also has a guide link at the top of its own form.
+          </Text>
+        </Stack>
+      </Card>
+    </Box>
+  )
+}

--- a/studio/sanity.config.ts
+++ b/studio/sanity.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'sanity'
 import {structureTool} from 'sanity/structure'
 import {visionTool} from '@sanity/vision'
+import {EditingGuidePane} from './components/EditingGuidePane'
 import {schemaTypes} from './schemaTypes'
 
 export default defineConfig({
@@ -29,6 +30,16 @@ export default defineConfig({
         return S.list()
           .title('Content')
           .items([
+            // "Start here" help entry, pinned at the top of the list.
+            S.listItem()
+              .id('editingGuide')
+              .title('📖 Start here')
+              .child(
+                S.component(EditingGuidePane)
+                  .id('editingGuide')
+                  .title('Editing guide'),
+              ),
+            S.divider(),
             ...singletons.map((s) =>
               S.listItem()
                 .id(s.id)


### PR DESCRIPTION
## What

Adds **`docs/sanity-guide.md`** — a single overview for how the team updates orcasound.tech in Sanity. We already had per-page guides (`editing-*.md`), but no central entry point. This ties them together and states the rules that apply everywhere, so they're not repeated in each page guide.

Covers:
- Signing in to the Studio + who to ask for access.
- The two kinds of content: **fixed pages** (with a table linking each page's `editing-*.md` guide) and the **blog** (collection of posts).
- **Rules that apply everywhere:** must Publish, empty-field fallbacks, images, ~1 min to go live, don't change existing slugs.
- **Developer notes:** schema changes need `npx sanity deploy`, the env vars, and the content-vs-code split.

## Notes

- Docs only — no code/behavior changes.
- Closes #405. Part of the Sanity migration epic #341.
